### PR TITLE
Respect text size scaling accessibility setting on Windows 11

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5884,6 +5884,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "windows 0.61.1",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,7 @@ uuid = "1.16.0"
 tauri-plugin-store = "2"
 tauri-plugin-notification = "2"
 
-[dependencies.windows]
+[target.'cfg(windows)'.dependencies.windows]
 version = "0.61"
 features = [
     "Data_Xml_Dom",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,18 @@ uuid = "1.16.0"
 tauri-plugin-store = "2"
 tauri-plugin-notification = "2"
 
+[dependencies.windows]
+version = "0.61"
+features = [
+    "Data_Xml_Dom",
+    "Win32_Security",
+    "Win32_System_Threading",
+    "Win32_UI_WindowsAndMessaging",
+	"Win32_Foundation",
+    "Win32_System_WinRT", # WinRT API を使うために必要
+    "UI_ViewManagement", # UISettings を使うために必要
+]
+
 [profile.dev]
 incremental = true # Compile your binary in smaller steps.
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,11 +34,11 @@ tauri-plugin-notification = "2"
 [target.'cfg(windows)'.dependencies.windows]
 version = "0.61"
 features = [
-    "Data_Xml_Dom",
-    "Win32_Security",
-    "Win32_System_Threading",
-    "Win32_UI_WindowsAndMessaging",
-	"Win32_Foundation",
+    # "Data_Xml_Dom",
+    # "Win32_Security",
+    # "Win32_System_Threading",
+    # "Win32_UI_WindowsAndMessaging",
+	# "Win32_Foundation",
     "Win32_System_WinRT", # WinRT API を使うために必要
     "UI_ViewManagement", # UISettings を使うために必要
 ]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,7 +11,7 @@ use tauri_plugin_opener::OpenerExt;
 // モジュール宣言を追加
 mod ble;
 mod common;
-
+mod window;
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -27,7 +27,8 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             common::print_rust,
             ble::list_battery_devices,
-            ble::get_battery_info
+            ble::get_battery_info,
+            window::get_windows_text_scale_factor,
         ])
         .setup(|app| {
             #[cfg(desktop)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ use tauri_plugin_opener::OpenerExt;
 mod ble;
 mod common;
 mod window;
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -1,0 +1,34 @@
+use tauri;
+#[cfg(target_os = "windows")]
+use windows::UI::ViewManagement::UISettings;
+
+#[tauri::command]
+pub fn get_windows_text_scale_factor() -> f64 {
+    #[cfg(target_os = "windows")]
+    {
+        match UISettings::new() {
+            Ok(settings) => {
+                match settings.TextScaleFactor() {
+                    Ok(factor) => {
+                        println!("Text scale factor: {}", factor);
+                        factor
+                    }
+                    Err(e) => {
+                        eprintln!("Failed to get TextScaleFactor: {:?}. Using default 1.0", e);
+                        1.0
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("Failed to create UISettings: {:?}. Using default 1.0", e);
+                1.0
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        println!("Non-Windows OS detected. Using default text scale factor 1.0");
+        1.0
+    }
+}

--- a/src/utils/window.ts
+++ b/src/utils/window.ts
@@ -21,7 +21,7 @@ export async function resizeWindow(x: number, y: number) {
 
 export async function resizeWindowToContent() {
     const width = document.getElementById('app')?.clientWidth ?? 0;
-    const height = document.getElementById('app')?.scrollHeight ?? 0;
+    const height = document.getElementById('app')?.clientHeight ?? 0;
     resizeWindow(width, height);
 }
 

--- a/src/utils/window.ts
+++ b/src/utils/window.ts
@@ -3,12 +3,18 @@ import { Position, moveWindow } from '@tauri-apps/plugin-positioner';
 import { printRust } from './common';
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { isTrayPositionSet } from './tray';
+import { invoke } from '@tauri-apps/api/core';
 
 export async function resizeWindow(x: number, y: number) {
-	printRust(`resizeWindow: ${x} ${y}`);
+	printRust(`resizeWindow: ${x}x${y}`);
+    const scaleFactor = await invoke<number>('get_windows_text_scale_factor');
+    const width = x * scaleFactor;
+    const height = y * scaleFactor;
+    printRust(`scaled size: ${width}x${height}`);
+
 	const window = getCurrentWebviewWindow();
 	if (window) {
-		await window.setSize(new LogicalSize(x, y));
+		await window.setSize(new LogicalSize(width, height));
 	}
     moveWindowToTrayCenter();
 }


### PR DESCRIPTION
## Description

- Close #4 

## Implementation details

In present implementation, the window is automatically resized to fit with the clientWidth/Height of #app element, but the values do not change when the text size scaling accessibility setting is changed, nor Tauri `window.setSize()` method does not respect the scale factor.

So, I've added a new function `get_windows_text_scale_factor()` to get the text size scale factor from the system using [windows crate](https://crates.io/crates/windows) and scale the window size accordingly when resizing the window.
