### PR TITLE
Feat/macos adhoc signing

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -52,7 +52,9 @@
     ],
     "resources": [
       "icons/icon_template.png"
-    ]
-  },
-  "signingIdentity": "-"
+    ],
+    "macOS": {
+      "signingIdentity": "-"
+    }
+  }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -53,5 +53,6 @@
     "resources": [
       "icons/icon_template.png"
     ]
-  }
+  },
+  "signingIdentity": "-"
 }


### PR DESCRIPTION
See https://v2.tauri.app/ja/distribute/sign/macos/#ad-hoc-signing

Now the macOS build shows "Apple can’t check app for malicious software" instead of "the app is damaged" when opened.