### PR TITLE
fix(linux): resolve system tray left click behavior

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2302,6 +2302,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ksni"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9eeb3f510b6148ae68f963af2c1fbb0de4d9e4e05f82813cfb319837c3ad2b"
+dependencies = [
+ "futures-util",
+ "pastey",
+ "serde",
+ "tokio",
+ "zbus",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3036,6 +3049,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pathdiff"
@@ -5008,8 +5027,10 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -6498,6 +6519,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "uuid",
@@ -6622,6 +6644,7 @@ dependencies = [
  "bluest",
  "csv",
  "futures-util",
+ "ksni",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -6645,7 +6668,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
- "windows 0.48.0",
+ "windows 0.61.3",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -64,6 +64,9 @@ tauri-plugin-autostart = "2"
 tauri-plugin-positioner = "2"
 tauri-plugin-single-instance = "2"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+ksni = "0.3.5"
+
 [target.'cfg(windows)'.dependencies.windows]
 version = "~0"
 features = [

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 use ansi_term::Color;
+use tauri::Manager;
 use tauri_plugin_autostart::MacosLauncher;
 
 mod ble;
@@ -20,6 +21,11 @@ const LOG_LEVEL: log::LevelFilter = log::LevelFilter::Warn;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    #[cfg(target_os = "linux")]
+    {
+        std::env::set_var("GDK_BACKEND", "x11");
+    }
+
     tauri::Builder::default()
         .plugin(tauri_plugin_os::init())
         .plugin(
@@ -73,8 +79,15 @@ pub fn run() {
             history::append_battery_history,
             history::read_battery_history,
             tray::update_tray_battery_icon,
+            tray::update_manual_positioning,
         ])
         .setup(|app| {
+            app.manage(tray::TrayState {
+                manual_positioning: std::sync::atomic::AtomicBool::new(false),
+                #[cfg(target_os = "linux")]
+                tray_handle: std::sync::Mutex::new(None),
+            });
+
             tray::init_tray(app.handle().clone());
 
             #[cfg(target_os = "macos")]

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,8 +1,100 @@
 use crate::tray_battery_payload::TrayBatteryPayload;
+use std::sync::{atomic::{AtomicBool, Ordering}, Mutex};
 use tauri::{
     tray::{MouseButton, MouseButtonState, TrayIconEvent},
-    AppHandle, Emitter,
+    AppHandle, Emitter, Manager,
 };
+use ksni::TrayMethods;
+
+pub struct TrayState {
+    pub manual_positioning: AtomicBool,
+    #[cfg(target_os = "linux")]
+    pub tray_handle: Mutex<Option<ksni::Handle<LinuxTray>>>,
+}
+
+#[cfg(target_os = "linux")]
+pub struct LinuxTray {
+    app: AppHandle,
+    icon: ksni::Icon,
+}
+
+#[cfg(target_os = "linux")]
+impl ksni::Tray for LinuxTray {
+    fn id(&self) -> String {
+        "zmk-battery-center".into()
+    }
+
+    fn icon_pixmap(&self) -> Vec<ksni::Icon> {
+        vec![self.icon.clone()]
+    }
+
+    fn activate(&mut self, _x: i32, _y: i32) {
+        let _ = self.app.emit("tray_left_click", ());
+    }
+
+    fn menu(&self) -> Vec<ksni::MenuItem<Self>> {
+        use ksni::menu::*;
+
+        let state = self.app.state::<TrayState>();
+        let is_manual = state.manual_positioning.load(Ordering::Relaxed);
+        let manual_label = if is_manual {
+            "✔ Manual window positioning"
+        } else {
+            "  Manual window positioning"
+        };
+
+        vec![
+            StandardItem {
+                label: "Show".into(),
+                activate: Box::new(|this: &mut Self| {
+                    let _ = this.app.emit("tray_left_click", ());
+                }),
+                ..Default::default()
+            }
+            .into(),
+            SubMenu {
+                label: "Control".into(),
+                submenu: vec![
+                    StandardItem {
+                        label: "Refresh window".into(),
+                        activate: Box::new(|this: &mut Self| {
+                            let _ = this.app.emit("tray_menu_refresh", ());
+                        }),
+                        ..Default::default()
+                    }
+                    .into(),
+                    StandardItem {
+                        label: manual_label.into(),
+                        activate: Box::new(|this: &mut Self| {
+                            let _ = this.app.emit("tray_menu_toggle_manual_positioning", ());
+                        }),
+                        ..Default::default()
+                    }
+                    .into(),
+                ],
+                ..Default::default()
+            }
+            .into(),
+            StandardItem {
+                label: "About".into(),
+                activate: Box::new(|this: &mut Self| {
+                    let _ = this.app.emit("tray_menu_about", ());
+                }),
+                ..Default::default()
+            }
+            .into(),
+            MenuItem::Separator,
+            StandardItem {
+                label: "Quit".into(),
+                activate: Box::new(|this: &mut Self| {
+                    this.app.exit(0);
+                }),
+                ..Default::default()
+            }
+            .into(),
+        ]
+    }
+}
 
 #[tauri::command]
 pub fn update_tray_battery_icon(
@@ -23,47 +115,104 @@ pub fn update_tray_battery_icon(
     }
 }
 
-pub fn init_tray(app_handle: AppHandle) {
-    let tray = app_handle.tray_by_id("tray_icon").unwrap();
-
-    #[cfg(target_os = "macos")]
+#[tauri::command]
+pub async fn update_manual_positioning(
+    state: tauri::State<'_, TrayState>,
+    enabled: bool,
+) -> Result<(), String> {
+    state.manual_positioning.store(enabled, Ordering::Relaxed);
+    #[cfg(target_os = "linux")]
     {
-        use tauri::Manager;
-        if let Ok(icon_path) = app_handle
-            .path()
-            .resolve("icons/icon_template.png", tauri::path::BaseDirectory::Resource)
-        {
-            if let Ok(icon) = tauri::image::Image::from_path(&icon_path) {
-                let _ = tray.set_icon(Some(icon));
-            }
+        let handle_opt = {
+            let guard = state.tray_handle.lock().unwrap();
+            guard.clone()
+        };
+        if let Some(handle) = handle_opt {
+            let _ = handle.update(|_| {}).await;
         }
-        let _ = tray.set_icon_as_template(true);
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn init_linux_tray(app_handle: AppHandle) {
+    use tauri::image::Image;
+
+    let tauri_image = Image::from_bytes(include_bytes!("../icons/32x32.png")).unwrap();
+    let width = tauri_image.width();
+    let height = tauri_image.height();
+    let rgba_bytes = tauri_image.rgba();
+
+    let mut argb_bytes = rgba_bytes.to_vec();
+    for pixel in argb_bytes.chunks_exact_mut(4) {
+        pixel.rotate_right(1); // RGBA -> ARGB
     }
 
-    tray.on_tray_icon_event(|tray_handle, event| {
-        let app = tray_handle.app_handle();
+    let ksni_icon = ksni::Icon {
+        width: width as i32,
+        height: height as i32,
+        data: argb_bytes,
+    };
 
-        // Let positioner know about the event
-        tauri_plugin_positioner::on_tray_event(app, &event);
+    let tray = LinuxTray {
+        app: app_handle.clone(),
+        icon: ksni_icon,
+    };
 
-        // Let frontend know about the event
-        let _ = app.emit("tray_event", event.clone());
+    let handle = tauri::async_runtime::block_on(tray.spawn()).unwrap();
 
-        // Handle click event
-        match event {
-            TrayIconEvent::Click {
-                button: MouseButton::Left,
-                button_state: MouseButtonState::Up,
-                ..
-            } => {
-                let _ = app.emit("tray_left_click", event.clone());
+    let state = app_handle.state::<TrayState>();
+    *state.tray_handle.lock().unwrap() = Some(handle);
+}
+
+pub fn init_tray(app_handle: AppHandle) {
+    #[cfg(target_os = "linux")]
+    {
+        init_linux_tray(app_handle);
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let tray = app_handle.tray_by_id("tray_icon").unwrap();
+
+        #[cfg(target_os = "macos")]
+        {
+            if let Ok(icon_path) = app_handle
+                .path()
+                .resolve("icons/icon_template.png", tauri::path::BaseDirectory::Resource)
+            {
+                if let Ok(icon) = tauri::image::Image::from_path(&icon_path) {
+                    let _ = tray.set_icon(Some(icon));
+                }
             }
-            TrayIconEvent::Click {
-                button: MouseButton::Right,
-                button_state: MouseButtonState::Up,
-                ..
-            } => {}
-            _ => {}
+            let _ = tray.set_icon_as_template(true);
         }
-    });
+
+        tray.on_tray_icon_event(|tray_handle, event| {
+            let app = tray_handle.app_handle();
+
+            // Let positioner know about the event
+            tauri_plugin_positioner::on_tray_event(app, &event);
+
+            // Let frontend know about the event
+            let _ = app.emit("tray_event", event.clone());
+
+            // Handle click event
+            match event {
+                TrayIconEvent::Click {
+                    button: MouseButton::Left,
+                    button_state: MouseButtonState::Up,
+                    ..
+                } => {
+                    let _ = app.emit("tray_left_click", event.clone());
+                }
+                TrayIconEvent::Click {
+                    button: MouseButton::Right,
+                    button_state: MouseButtonState::Up,
+                    ..
+                } => {}
+                _ => {}
+            }
+        });
+    }
 }

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,5 @@
+{
+  "app": {
+    "trayIcon": null
+  }
+}

--- a/src/components/TopRightButtons.tsx
+++ b/src/components/TopRightButtons.tsx
@@ -18,7 +18,7 @@ interface TopRightButtonsProps {
  */
 const TopRightButtons: React.FC<TopRightButtonsProps> = ({ buttons }) => {
 	return (
-		<div className="flex flex-row ml-auto justify-end">
+		<div className="flex flex-row ml-auto justify-end pr-2 pt-0.5 gap-1">
 			{buttons.map((btn) => (
 				<Button
 					key={btn.ariaLabel}

--- a/src/hooks/useTrayEvents.ts
+++ b/src/hooks/useTrayEvents.ts
@@ -2,12 +2,14 @@ import { useEffect, useRef } from 'react';
 import { listen } from '@tauri-apps/api/event';
 import { TrayIcon, TrayIconEvent } from '@tauri-apps/api/tray';
 import { Menu, Submenu, CheckMenuItem } from '@tauri-apps/api/menu';
-import { isWindowVisible, showWindow, hideWindow, moveWindowToTrayCenter, setWindowFocus, setTrayPositionSet } from '@/utils/window';
+import { isWindowVisible, showWindow, hideWindow, moveWindowToTrayCenter, setWindowFocus, setTrayPositionSet, moveWindowTo } from '@/utils/window';
 import { exitApp } from '@/utils/common';
 import { stopAllBatteryMonitors } from '@/utils/ble';
 import { logger } from '@/utils/log';
 import { Config } from '@/utils/config';
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
+import { platform } from '@tauri-apps/plugin-os';
+import { invoke } from '@tauri-apps/api/core';
 
 interface UseTrayEventsOptions {
     config: Config;
@@ -16,34 +18,49 @@ interface UseTrayEventsOptions {
 }
 
 export function useTrayEvents({ config, isConfigLoaded, onManualWindowPositioningChange }: UseTrayEventsOptions) {
-    const manualWindowPositioningRef = useRef(config.manualWindowPositioning);
-    const onManualWindowPositioningChangeRef = useRef(onManualWindowPositioningChange);
+    const configRef = useRef(config);
+    configRef.current = config;
 
-    manualWindowPositioningRef.current = config.manualWindowPositioning;
+    const onManualWindowPositioningChangeRef = useRef(onManualWindowPositioningChange);
     onManualWindowPositioningChangeRef.current = onManualWindowPositioningChange;
+
+    // Synchronize backend state whenever manualWindowPositioning config changes
+    useEffect(() => {
+        if (!isConfigLoaded) return;
+        if (platform() === 'linux') {
+            invoke('update_manual_positioning', { enabled: config.manualWindowPositioning })
+                .catch(err => logger.error(`Failed to update manual positioning in backend: ${err}`));
+        }
+    }, [config.manualWindowPositioning, isConfigLoaded]);
 
     useEffect(() => {
         if (!isConfigLoaded) return;
 
         let unlistenTrayEvent: (() => void) | null = null;
         let unlistenTrayLeftClick: (() => void) | null = null;
+        let unlistenTrayMenuRefresh: (() => void) | null = null;
+        let unlistenTrayMenuToggleManual: (() => void) | null = null;
+        let unlistenTrayMenuAbout: (() => void) | null = null;
 
         const setupTray = async () => {
-            const tray = await TrayIcon.getById('tray_icon');
-            if (!tray) {
+            const isLinux = platform() === 'linux';
+            const tray = isLinux ? null : await TrayIcon.getById('tray_icon');
+            if (!isLinux && !tray) {
                 logger.error('Tray icon not found');
                 return;
             }
 
             // Set tray position flag on first tray event
             let isTrayPositionSet = false;
-            unlistenTrayEvent = await listen<TrayIconEvent>('tray_event', () => {
-                if (!isTrayPositionSet) {
-                    isTrayPositionSet = true;
-                    setTrayPositionSet(true);
-                    logger.info('Tray position set');
-                }
-            });
+            if (tray) {
+                unlistenTrayEvent = await listen<TrayIconEvent>('tray_event', () => {
+                    if (!isTrayPositionSet) {
+                        isTrayPositionSet = true;
+                        setTrayPositionSet(true);
+                        logger.info('Tray position set');
+                    }
+                });
+            }
 
             // Handle tray left click
             unlistenTrayLeftClick = await listen('tray_left_click', async () => {
@@ -52,8 +69,10 @@ export function useTrayEvents({ config, isConfigLoaded, onManualWindowPositionin
                     hideWindow();
                 } else {
                     showWindow();
-                    if (!manualWindowPositioningRef.current) {
+                    if (!configRef.current.manualWindowPositioning) {
                         moveWindowToTrayCenter();
+                    } else {
+                        await moveWindowTo(configRef.current.windowPosition.x, configRef.current.windowPosition.y);
                     }
                     setWindowFocus();
                 }
@@ -65,10 +84,12 @@ export function useTrayEvents({ config, isConfigLoaded, onManualWindowPositionin
                     {
                         id: 'show',
                         text: 'Show',
-                        action: () => {
+                        action: async () => {
                             showWindow();
-                            if (!manualWindowPositioningRef.current) {
+                            if (!configRef.current.manualWindowPositioning) {
                                 moveWindowToTrayCenter();
+                            } else {
+                                await moveWindowTo(configRef.current.windowPosition.x, configRef.current.windowPosition.y);
                             }
                         }
                     },
@@ -83,25 +104,28 @@ export function useTrayEvents({ config, isConfigLoaded, onManualWindowPositionin
                                     await stopAllBatteryMonitors();
                                     location.reload();
                                     showWindow();
-                                    if (!manualWindowPositioningRef.current) {
+                                    if (!configRef.current.manualWindowPositioning) {
                                         moveWindowToTrayCenter();
+                                    } else {
+                                        await moveWindowTo(configRef.current.windowPosition.x, configRef.current.windowPosition.y);
                                     }
                                 },
                             },
                             {
                                 id: 'manual_window_positioning',
                                 text: 'Manual window positioning',
-                                checked: config.manualWindowPositioning,
+                                checked: configRef.current.manualWindowPositioning,
                                 action: async (trayId: string) => {
                                     const controlMenu = await menu?.get('control') as Submenu | null;
                                     const thisMenu = await controlMenu?.get(trayId) as CheckMenuItem | null;
                                     if (!thisMenu) return;
 
                                     const isChecked = await thisMenu.isChecked();
-                                    manualWindowPositioningRef.current = isChecked;
                                     showWindow();
-                                    if (!manualWindowPositioningRef.current) {
+                                    if (!isChecked) {
                                         moveWindowToTrayCenter();
+                                    } else {
+                                        await moveWindowTo(configRef.current.windowPosition.x, configRef.current.windowPosition.y);
                                     }
 
                                     onManualWindowPositioningChangeRef.current(isChecked);
@@ -139,8 +163,55 @@ export function useTrayEvents({ config, isConfigLoaded, onManualWindowPositionin
                 ]
             });
 
-            tray.setMenu(menu);
-            tray.setShowMenuOnLeftClick(false);
+            if (platform() !== 'linux') {
+                if (tray) {
+                    await tray.setMenu(menu);
+                    await tray.setShowMenuOnLeftClick(false);
+                }
+            } else {
+                // Initialize Rust state
+                await invoke('update_manual_positioning', { enabled: configRef.current.manualWindowPositioning });
+
+                unlistenTrayMenuRefresh = await listen('tray_menu_refresh', async () => {
+                    await stopAllBatteryMonitors();
+                    location.reload();
+                    showWindow();
+                    if (!configRef.current.manualWindowPositioning) {
+                        moveWindowToTrayCenter();
+                    } else {
+                        await moveWindowTo(configRef.current.windowPosition.x, configRef.current.windowPosition.y);
+                    }
+                });
+
+                unlistenTrayMenuToggleManual = await listen('tray_menu_toggle_manual_positioning', async () => {
+                    const isChecked = !configRef.current.manualWindowPositioning;
+                    showWindow();
+                    if (!isChecked) {
+                        moveWindowToTrayCenter();
+                    } else {
+                        await moveWindowTo(configRef.current.windowPosition.x, configRef.current.windowPosition.y);
+                    }
+                    onManualWindowPositioningChangeRef.current(isChecked);
+                    await invoke('update_manual_positioning', { enabled: isChecked });
+                });
+
+                unlistenTrayMenuAbout = await listen('tray_menu_about', async () => {
+                    let aboutWindow = await WebviewWindow.getByLabel('about');
+                    if (!aboutWindow) {
+                        aboutWindow = new WebviewWindow('about', {
+                            url: 'about.html',
+                            title: 'zmk-battery-center - About',
+                            width: 600,
+                            height: 500,
+                            center: true,
+                            resizable: true,
+                            decorations: true,
+                        });
+                    }
+                    await aboutWindow.show();
+                    await aboutWindow.setFocus();
+                });
+            }
         };
 
         setupTray();
@@ -148,6 +219,9 @@ export function useTrayEvents({ config, isConfigLoaded, onManualWindowPositionin
         return () => {
             if (unlistenTrayEvent) unlistenTrayEvent();
             if (unlistenTrayLeftClick) unlistenTrayLeftClick();
+            if (unlistenTrayMenuRefresh) unlistenTrayMenuRefresh();
+            if (unlistenTrayMenuToggleManual) unlistenTrayMenuToggleManual();
+            if (unlistenTrayMenuAbout) unlistenTrayMenuAbout();
         };
     }, [isConfigLoaded]);
 }

--- a/src/hooks/useWindowEvents.ts
+++ b/src/hooks/useWindowEvents.ts
@@ -38,6 +38,13 @@ export function useWindowEvents({ config, isConfigLoaded, onWindowPositionChange
         let unlistenOnFocusChanged: (() => void) | null = null;
 
         const saveWindowPosition = async (position: { x: number; y: number }) => {
+            const isVisible = await window.isVisible();
+            const isFocused = await window.isFocused();
+            if (!isVisible || !isFocused) {
+                logger.debug(`Skipped saving window position: isVisible=${isVisible}, isFocused=${isFocused} (position: ${position.x}, ${position.y})`);
+                return;
+            }
+
             if (await platform() === 'macos') {
                 // Convert logical position to physical position
                 const monitor = await currentMonitor();
@@ -53,6 +60,7 @@ export function useWindowEvents({ config, isConfigLoaded, onWindowPositionChange
 
         const setupListeners = async () => {
             unlistenOnMoved = await window.onMoved(async ({ payload: position }) => {
+                logger.debug(`Window onMoved event received: x=${position.x}, y=${position.y}`);
                 if (!isWindowMovingRef.current) {
                     logger.debug("Window move start");
                 }

--- a/src/utils/window.ts
+++ b/src/utils/window.ts
@@ -33,8 +33,14 @@ async function waitForWindowMoveEnd(){
 export async function resizeWindow(x: number, y: number) {
 	logger.info(`resizeWindow: ${x}x${y}`);
     const scaleFactor = await invoke<number>('get_windows_text_scale_factor');
-    const width = x * scaleFactor;
-    const height = y * scaleFactor;
+    let width = x * scaleFactor;
+    let height = y * scaleFactor;
+
+    if (currentPlatform === 'linux') {
+        width += 16;
+        height += 8;
+    }
+
     logger.info(`scaled size: ${width}x${height}`);
 
 	await appWindow.setSize(new LogicalSize(width, height));


### PR DESCRIPTION
This PR fixes a bug on Linux where left-clicking the system tray icon registers as a right-click (opening the context menu) instead of toggling the main window, and resolves issues with manual window positioning/coordinate-tracking on Wayland.

The Problems
Tray Click Behavior: On Linux, the default GTK/AppIndicator tray intercepts all click events to display the context menu. Standard left-click events are never bubbled up to the application, making it impossible to toggle window visibility on left-click.
Wayland Positioning: Under native Wayland sessions, absolute positioning coordinates are blocked by the compositor, causing coordinate tracking (onMoved) to always report (0, 0).
Closing Position Overwrite: When the window is hidden, focus loss and unmapping events trigger a trailing onMoved event with (0, 0), which overwrote the last valid manual position.
Window clipping: Under Linux/GTK, window frame metrics (shadows, borders) are sometimes counted in setSize, causing the HTML container to clip slightly on the right edge, making the Settings button hard to click.
Solutions Implemented
1. Backend (Rust / D-Bus SNI)
Set trayIcon: null inside tauri.linux.conf.json to disable the default GTK AppIndicator tray on Linux.
Integrated the ksni crate to implement a custom D-Bus StatusNotifierItem.
Handled the activate event (left-click) to emit a tray_left_click event to the frontend, and built a dynamic context menu for D-Bus client environments.
Unconditionally set GDK_BACKEND=x11 on Linux. This forces the application to run via XWayland in Wayland environments, restoring full support for absolute window placement and tracking.
2. Frontend
Modified useTrayEvents.ts to proceed without a native TrayIcon reference on Linux, continuing to listen for the new D-Bus tray events.
Updated useTrayEvents.ts to explicitly call moveWindowTo(config.windowPosition.x, config.windowPosition.y) when showing the window if manual positioning is enabled, ensuring coordinates are enforced upon window remapping.
Added both isVisible() and isFocused() checks in useWindowEvents.ts's saveWindowPosition to ensure coordinates are only saved when the window is active, preventing focus-loss or window-hide events from overwriting coordinates with (0, 0).
Appended a small safety margin (width + 16px, height + 8px) on Linux inside the resizeWindow helper in window.ts to prevent frame decorations from clipping the Settings button.
Verification
Verified compilation and test runs successfully locally (bun run test passes all 120 frontend and backend tests).
Confirmed left-clicking toggles window visibility, right-clicking opens the D-Bus context menu, and manual window positioning accurately tracks and restores the window position on reopening.
