### PR TITLE
feat: customizable battery notification thresholds

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -195,6 +195,8 @@ function App() {
 		commitRegisteredDevices,
 		pushNotification: config.pushNotification,
 		pushNotificationWhen: config.pushNotificationWhen,
+		lowBatteryThreshold: config.lowBatteryThreshold,
+		highBatteryThreshold: config.highBatteryThreshold,
 		autoCollapseDisconnectedDevices: config.autoCollapseDisconnectedDevices,
 	});
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { useConfigContext } from "@/context/ConfigContext";
 import Settings from "@/components/Settings";
 import { sendNotification } from "./utils/notification";
 import { FETCH_INTERVAL_AUTO, NotificationType } from "./utils/config";
+import { notifyBatteryEdgeTransitions } from "./utils/batteryEdgeNotification";
 import { fireAndForget, withTimeout } from "./utils/common";
 import { platform } from "@tauri-apps/plugin-os";
 import { useWindowEvents } from "@/hooks/useWindowEvents";
@@ -270,7 +271,6 @@ function App() {
 		const unlistenPromise = listen<BatteryInfoNotificationEvent>("battery-info-notification", event => {
 			const payload = event.payload;
 			const batteryLevel = payload.battery_info.battery_level;
-			// Record battery history for notification-mode updates
 			if (batteryLevel !== null) {
 				const device = registeredDevicesRef.current.find(d => d.id === payload.id);
 				if (device) {
@@ -289,9 +289,20 @@ function App() {
 				if (device.id !== payload.id) {
 					return device;
 				}
+				const newBatteryInfos = upsertBatteryInfo(device.batteryInfos, payload.battery_info);
+				notifyBatteryEdgeTransitions({
+					deviceDisplayName: getRegisteredDeviceDisplayName(device),
+					deviceId: device.id,
+					prevBatteryInfos: device.batteryInfos,
+					newBatteryInfos,
+					lowBatteryThreshold: config.lowBatteryThreshold,
+					highBatteryThreshold: config.highBatteryThreshold,
+					pushNotification: config.pushNotification,
+					pushNotificationWhen: config.pushNotificationWhen,
+				});
 				return expandIfConnected({
 					...device,
-					batteryInfos: upsertBatteryInfo(device.batteryInfos, payload.battery_info),
+					batteryInfos: newBatteryInfos,
 					isDisconnected: false,
 				}, autoCollapseDisconnectedDevicesRef.current);
 			}));
@@ -303,7 +314,7 @@ function App() {
 				"Failed to clean up battery info listener",
 			);
 		};
-	}, [isDeviceLoaded, config.autoCollapseDisconnectedDevices, commitRegisteredDevices, autoCollapseDisconnectedDevicesRef, registeredDevicesRef]);
+	}, [isDeviceLoaded, config.autoCollapseDisconnectedDevices, config.pushNotification, config.pushNotificationWhen, config.lowBatteryThreshold, config.highBatteryThreshold, commitRegisteredDevices, autoCollapseDisconnectedDevicesRef, registeredDevicesRef]);
 
 	const previousAutoCollapseDisconnectedDevicesRef = useRef(config.autoCollapseDisconnectedDevices);
 	useEffect(() => {

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,6 +1,14 @@
 import React from "react";
 import Button from "./Button";
-import { FETCH_INTERVAL_AUTO, NotificationType, TrayIconComponent } from "../utils/config";
+import {
+	FETCH_INTERVAL_AUTO,
+	NotificationType,
+	TrayIconComponent,
+	MIN_BATTERY_THRESHOLD,
+	MAX_BATTERY_THRESHOLD,
+	clampBatteryThreshold,
+	defaultConfig,
+} from "../utils/config";
 import { useTheme, type Theme } from "@/context/theme-provider";
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch"
@@ -34,6 +42,72 @@ interface SettingsScreenProps {
 const Dot = () => (
 	<span className="mr-1 font-bold">•</span>
 );
+
+interface BatteryThresholdInputProps {
+	value: number;
+	disabled: boolean;
+	disabledTitle?: string;
+	fallback: number;
+	min?: number;
+	max?: number;
+	onCommit: (value: number) => void;
+	ariaLabel: string;
+}
+
+function BatteryThresholdInput({
+	value,
+	disabled,
+	disabledTitle,
+	fallback,
+	min = MIN_BATTERY_THRESHOLD,
+	max = MAX_BATTERY_THRESHOLD,
+	onCommit,
+	ariaLabel,
+}: BatteryThresholdInputProps) {
+	const [draft, setDraft] = React.useState<string>(String(value));
+
+	React.useEffect(() => {
+		setDraft(String(value));
+	}, [value]);
+
+	const commit = () => {
+		if (draft.trim() === "") {
+			setDraft(String(value));
+			return;
+		}
+		const parsed = Number(draft);
+		const next = clampBatteryThreshold(parsed, fallback, { min, max });
+		setDraft(String(next));
+		if (next !== value) {
+			onCommit(next);
+		}
+	};
+
+	return (
+		<input
+			type="number"
+			min={min}
+			max={max}
+			step={1}
+			value={draft}
+			disabled={disabled}
+			aria-label={ariaLabel}
+			title={disabled ? disabledTitle : undefined}
+			onChange={e => setDraft(e.target.value)}
+			onBlur={commit}
+			onKeyDown={e => {
+				if (e.key === "Enter") {
+					e.currentTarget.blur();
+				}
+			}}
+			className={cn(
+				"mx-1 h-7 w-12 rounded border border-input bg-background px-1 text-center text-sm",
+				"focus:outline-none focus:ring-1 focus:ring-ring",
+				"disabled:cursor-not-allowed disabled:opacity-50",
+			)}
+		/>
+	);
+}
 
 const fetchIntervalOptions = [
 	{ label: 'Auto (experimental)', value: FETCH_INTERVAL_AUTO },
@@ -230,14 +304,55 @@ const Settings: React.FC<SettingsScreenProps> = ({
 						</div>
 						<ul className={`w-full space-y-0.5 pl-2 ${!config.pushNotification ? ' text-muted-foreground' : 'text-card-foreground'}`}>
 							<li className="flex items-center justify-between gap-3">
-								<div>
-									<Dot /> when battery level ≤ 20%
+								<div className="flex items-center gap-1">
+									<Dot /> when battery level ≤
+									<BatteryThresholdInput
+										value={config.lowBatteryThreshold}
+										disabled={!config.pushNotification || !config.pushNotificationWhen[NotificationType.LowBattery]}
+										disabledTitle={
+											!config.pushNotification
+												? "Enable push notifications to edit"
+												: "Enable the toggle on the right to edit"
+										}
+										fallback={defaultConfig.lowBatteryThreshold}
+										max={config.highBatteryThreshold - 1}
+										onCommit={value => setConfig(c => ({ ...c, lowBatteryThreshold: value }))}
+										ariaLabel="Low battery threshold"
+									/>
+									%
 								</div>
 								<Switch
 									checked={config.pushNotificationWhen[NotificationType.LowBattery]}
 									onCheckedChange={checked => setConfig(c => ({
 										...c,
 										pushNotificationWhen: { ...c.pushNotificationWhen, [NotificationType.LowBattery]: checked }
+									}))}
+									disabled={!config.pushNotification}
+								/>
+							</li>
+							<li className="flex items-center justify-between gap-3">
+								<div className="flex items-center gap-1">
+									<Dot /> when battery level ≥
+									<BatteryThresholdInput
+										value={config.highBatteryThreshold}
+										disabled={!config.pushNotification || !config.pushNotificationWhen[NotificationType.HighBattery]}
+										disabledTitle={
+											!config.pushNotification
+												? "Enable push notifications to edit"
+												: "Enable the toggle on the right to edit"
+										}
+										fallback={defaultConfig.highBatteryThreshold}
+										min={config.lowBatteryThreshold + 1}
+										onCommit={value => setConfig(c => ({ ...c, highBatteryThreshold: value }))}
+										ariaLabel="High battery threshold"
+									/>
+									%
+								</div>
+								<Switch
+									checked={config.pushNotificationWhen[NotificationType.HighBattery]}
+									onCheckedChange={checked => setConfig(c => ({
+										...c,
+										pushNotificationWhen: { ...c.pushNotificationWhen, [NotificationType.HighBattery]: checked }
 									}))}
 									disabled={!config.pushNotification}
 								/>

--- a/src/hooks/useBatteryPolling.ts
+++ b/src/hooks/useBatteryPolling.ts
@@ -6,10 +6,9 @@ import { emit } from "@tauri-apps/api/event";
 import { appendBatteryHistory } from "@/utils/batteryHistory";
 import { sendNotification } from "@/utils/notification";
 import { NotificationType } from "@/utils/config";
+import { notifyBatteryEdgeTransitions } from "@/utils/batteryEdgeNotification";
 import {
 	mergeBatteryInfos,
-	mapIsLowBattery,
-	mapIsHighBattery,
 	getRegisteredDeviceDisplayName,
 	type RegisteredDevice,
 } from "@/utils/appHelpers";
@@ -57,10 +56,6 @@ export function useBatteryPolling({
 
 	const updateBatteryInfo = useCallback(async (device: RegisteredDevice) => {
 		const isDisconnectedPrev = device.isDisconnected;
-		const lowThreshold = lowBatteryThresholdRef.current;
-		const highThreshold = highBatteryThresholdRef.current;
-		const isLowBatteryPrev = mapIsLowBattery(device.batteryInfos, lowThreshold);
-		const isHighBatteryPrev = mapIsHighBattery(device.batteryInfos, highThreshold);
 
 		let attempts = 0;
 		const maxAttempts = isDisconnectedPrev ? 1 : 3;
@@ -97,42 +92,16 @@ export function useBatteryPolling({
 					await sendNotification(`${getRegisteredDeviceDisplayName(device)} has been connected.`);
 				}
 
-				const displayName = getRegisteredDeviceDisplayName(device);
-				const notifyEdgeTransition = (
-					notificationType: NotificationType,
-					prev: boolean[],
-					curr: boolean[],
-					label: string,
-				) => {
-					if (!pushNotificationRef.current || !pushNotificationWhenRef.current[notificationType]) {
-						return;
-					}
-					for (let i = 0; i < curr.length && i < prev.length; i++) {
-						if (prev[i] || !curr[i]) continue;
-						const suffix = infoArray.length >= 2
-							? ' ' + (infoArray[i].user_description ?? 'Central')
-							: '';
-						const message = `${displayName}${suffix} has ${label} battery.`;
-						fireAndForget(
-							sendNotification(message),
-							`Failed to send ${label} battery notification for ${device.id}`,
-						);
-						logger.info(`${displayName} has ${label} battery.`);
-					}
-				};
-
-				notifyEdgeTransition(
-					NotificationType.LowBattery,
-					isLowBatteryPrev,
-					mapIsLowBattery(infoArray, lowThreshold),
-					'low',
-				);
-				notifyEdgeTransition(
-					NotificationType.HighBattery,
-					isHighBatteryPrev,
-					mapIsHighBattery(infoArray, highThreshold),
-					'high',
-				);
+				notifyBatteryEdgeTransitions({
+					deviceDisplayName: getRegisteredDeviceDisplayName(device),
+					deviceId: device.id,
+					prevBatteryInfos: device.batteryInfos,
+					newBatteryInfos: infoArray,
+					lowBatteryThreshold: lowBatteryThresholdRef.current,
+					highBatteryThreshold: highBatteryThresholdRef.current,
+					pushNotification: pushNotificationRef.current,
+					pushNotificationWhen: pushNotificationWhenRef.current,
+				});
 
 				return;
 			} catch {

--- a/src/hooks/useBatteryPolling.ts
+++ b/src/hooks/useBatteryPolling.ts
@@ -9,6 +9,7 @@ import { NotificationType } from "@/utils/config";
 import {
 	mergeBatteryInfos,
 	mapIsLowBattery,
+	mapIsHighBattery,
 	getRegisteredDeviceDisplayName,
 	type RegisteredDevice,
 } from "@/utils/appHelpers";
@@ -23,6 +24,8 @@ interface UseBatteryPollingOptions {
 	commitRegisteredDevices: (recipe: (current: RegisteredDevice[]) => RegisteredDevice[]) => void;
 	pushNotification: boolean;
 	pushNotificationWhen: Record<NotificationType, boolean>;
+	lowBatteryThreshold: number;
+	highBatteryThreshold: number;
 	autoCollapseDisconnectedDevices: boolean;
 }
 
@@ -35,20 +38,29 @@ export function useBatteryPolling({
 	commitRegisteredDevices,
 	pushNotification,
 	pushNotificationWhen,
+	lowBatteryThreshold,
+	highBatteryThreshold,
 	autoCollapseDisconnectedDevices,
 }: UseBatteryPollingOptions) {
 	const pushNotificationRef = useRef(pushNotification);
 	const pushNotificationWhenRef = useRef(pushNotificationWhen);
+	const lowBatteryThresholdRef = useRef(lowBatteryThreshold);
+	const highBatteryThresholdRef = useRef(highBatteryThreshold);
 	const autoCollapseDisconnectedDevicesRef = useRef(autoCollapseDisconnectedDevices);
 	useEffect(() => {
 		pushNotificationRef.current = pushNotification;
 		pushNotificationWhenRef.current = pushNotificationWhen;
+		lowBatteryThresholdRef.current = lowBatteryThreshold;
+		highBatteryThresholdRef.current = highBatteryThreshold;
 		autoCollapseDisconnectedDevicesRef.current = autoCollapseDisconnectedDevices;
-	}, [pushNotification, pushNotificationWhen, autoCollapseDisconnectedDevices]);
+	}, [pushNotification, pushNotificationWhen, lowBatteryThreshold, highBatteryThreshold, autoCollapseDisconnectedDevices]);
 
 	const updateBatteryInfo = useCallback(async (device: RegisteredDevice) => {
 		const isDisconnectedPrev = device.isDisconnected;
-		const isLowBatteryPrev = mapIsLowBattery(device.batteryInfos);
+		const lowThreshold = lowBatteryThresholdRef.current;
+		const highThreshold = highBatteryThresholdRef.current;
+		const isLowBatteryPrev = mapIsLowBattery(device.batteryInfos, lowThreshold);
+		const isHighBatteryPrev = mapIsHighBattery(device.batteryInfos, highThreshold);
 
 		let attempts = 0;
 		const maxAttempts = isDisconnectedPrev ? 1 : 3;
@@ -85,23 +97,42 @@ export function useBatteryPolling({
 					await sendNotification(`${getRegisteredDeviceDisplayName(device)} has been connected.`);
 				}
 
-				if(pushNotificationRef.current && pushNotificationWhenRef.current[NotificationType.LowBattery]){
-					const isLowBattery = mapIsLowBattery(infoArray);
-					const displayName = getRegisteredDeviceDisplayName(device);
-					for(let i = 0; i < isLowBattery.length && i < isLowBatteryPrev.length; i++){
-						if(!isLowBatteryPrev[i] && isLowBattery[i]){
-							fireAndForget(
-								sendNotification(`${displayName}${
-									infoArray.length >= 2 ?
-										' ' + (infoArray[i].user_description ?? 'Central')
-										: ''
-								} has low battery.`),
-								`Failed to send low battery notification for ${device.id}`,
-							);
-							logger.info(`${displayName} has low battery.`);
-						}
+				const displayName = getRegisteredDeviceDisplayName(device);
+				const notifyEdgeTransition = (
+					notificationType: NotificationType,
+					prev: boolean[],
+					curr: boolean[],
+					label: string,
+				) => {
+					if (!pushNotificationRef.current || !pushNotificationWhenRef.current[notificationType]) {
+						return;
 					}
-				}
+					for (let i = 0; i < curr.length && i < prev.length; i++) {
+						if (prev[i] || !curr[i]) continue;
+						const suffix = infoArray.length >= 2
+							? ' ' + (infoArray[i].user_description ?? 'Central')
+							: '';
+						const message = `${displayName}${suffix} has ${label} battery.`;
+						fireAndForget(
+							sendNotification(message),
+							`Failed to send ${label} battery notification for ${device.id}`,
+						);
+						logger.info(`${displayName} has ${label} battery.`);
+					}
+				};
+
+				notifyEdgeTransition(
+					NotificationType.LowBattery,
+					isLowBatteryPrev,
+					mapIsLowBattery(infoArray, lowThreshold),
+					'low',
+				);
+				notifyEdgeTransition(
+					NotificationType.HighBattery,
+					isHighBatteryPrev,
+					mapIsHighBattery(infoArray, highThreshold),
+					'high',
+				);
 
 				return;
 			} catch {

--- a/src/utils/__tests__/appHelpers.test.ts
+++ b/src/utils/__tests__/appHelpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mergeBatteryInfos, normalizeLoadedDevices, upsertBatteryInfo, getRegisteredDeviceDisplayName } from "../appHelpers";
+import { mapIsHighBattery, mapIsLowBattery, mergeBatteryInfos, normalizeLoadedDevices, upsertBatteryInfo, getRegisteredDeviceDisplayName } from "../appHelpers";
 
 describe("App helpers", () => {
 	describe("getRegisteredDeviceDisplayName", () => {
@@ -12,6 +12,35 @@ describe("App helpers", () => {
 			expect(getRegisteredDeviceDisplayName({ name: "BLE", displayName: "  " })).toBe("BLE");
 		});
 	});
+	describe("mapIsLowBattery", () => {
+		it("marks levels at or below threshold as low", () => {
+			const infos = [
+				{ battery_level: 30, user_description: "Left" },
+				{ battery_level: 20, user_description: "Right" },
+				{ battery_level: 19, user_description: "Central" },
+				{ battery_level: null, user_description: "Aux" },
+			];
+			expect(mapIsLowBattery(infos, 20)).toEqual([false, true, true, false]);
+		});
+
+		it("respects a custom threshold", () => {
+			const infos = [{ battery_level: 30, user_description: null }];
+			expect(mapIsLowBattery(infos, 50)).toEqual([true]);
+		});
+	});
+
+	describe("mapIsHighBattery", () => {
+		it("marks levels at or above threshold as high", () => {
+			const infos = [
+				{ battery_level: 94, user_description: "Left" },
+				{ battery_level: 95, user_description: "Right" },
+				{ battery_level: 100, user_description: "Central" },
+				{ battery_level: null, user_description: "Aux" },
+			];
+			expect(mapIsHighBattery(infos, 95)).toEqual([false, true, true, false]);
+		});
+	});
+
 	describe("upsertBatteryInfo", () => {
 		it("appends when user description is not present", () => {
 			const prev = [{ battery_level: 80, user_description: "Left" }];

--- a/src/utils/__tests__/config.test.ts
+++ b/src/utils/__tests__/config.test.ts
@@ -68,6 +68,7 @@ describe("config utils", () => {
 			autoStart: true,
 			fetchInterval: 60_000,
 			pushNotificationWhen: {
+				...defaultConfig.pushNotificationWhen,
 				low_battery: false,
 				disconnected: true,
 				connected: false,
@@ -176,6 +177,66 @@ describe("config utils", () => {
 		expect(enable).toHaveBeenCalledTimes(1);
 		expect(mockRequestNotificationPermission).toHaveBeenCalledTimes(1);
 		expect(mockLoggerInfo).toHaveBeenCalledWith("Notification permission granted");
+	});
+
+	it("clampBatteryThreshold clamps and rounds out-of-range values", async () => {
+		const { clampBatteryThreshold } = await import("../config");
+		expect(clampBatteryThreshold(0, 20)).toBe(1);
+		expect(clampBatteryThreshold(100, 95)).toBe(99);
+		expect(clampBatteryThreshold(50.6, 20)).toBe(51);
+		expect(clampBatteryThreshold(Number.NaN, 30)).toBe(30);
+		expect(clampBatteryThreshold(Number.POSITIVE_INFINITY, 30)).toBe(30);
+	});
+
+	it("clampBatteryThreshold honors custom min/max bounds", async () => {
+		const { clampBatteryThreshold } = await import("../config");
+		expect(clampBatteryThreshold(50, 20, { max: 40 })).toBe(40);
+		expect(clampBatteryThreshold(10, 80, { min: 50 })).toBe(50);
+		expect(clampBatteryThreshold(60, 20, { min: 30, max: 70 })).toBe(60);
+	});
+
+	it("loadSavedConfig clamps stored thresholds and falls back to defaults", async () => {
+		mockStore.get.mockResolvedValue({
+			lowBatteryThreshold: 0,
+			highBatteryThreshold: 250,
+		});
+
+		const { loadSavedConfig } = await import("../config");
+		const loaded = await loadSavedConfig();
+
+		expect(loaded.lowBatteryThreshold).toBe(1);
+		expect(loaded.highBatteryThreshold).toBe(99);
+	});
+
+	it("loadSavedConfig falls back to defaults when stored thresholds overlap", async () => {
+		mockStore.get.mockResolvedValue({
+			lowBatteryThreshold: 80,
+			highBatteryThreshold: 20,
+		});
+
+		const { loadSavedConfig, defaultConfig } = await import("../config");
+		const loaded = await loadSavedConfig();
+
+		expect(loaded.lowBatteryThreshold).toBe(defaultConfig.lowBatteryThreshold);
+		expect(loaded.highBatteryThreshold).toBe(defaultConfig.highBatteryThreshold);
+	});
+
+	it("loadSavedConfig deep-merges pushNotificationWhen so missing keys keep defaults", async () => {
+		mockStore.get.mockResolvedValue({
+			pushNotificationWhen: {
+				low_battery: false,
+				connected: false,
+				disconnected: false,
+			},
+		});
+
+		const { loadSavedConfig, defaultConfig } = await import("../config");
+		const loaded = await loadSavedConfig();
+
+		expect(loaded.pushNotificationWhen.low_battery).toBe(false);
+		expect(loaded.pushNotificationWhen.high_battery).toBe(defaultConfig.pushNotificationWhen.high_battery);
+		expect(loaded.pushNotificationWhen.connected).toBe(false);
+		expect(loaded.pushNotificationWhen.disconnected).toBe(false);
 	});
 
 	it("loadSavedConfig reuses config store so load is only invoked once", async () => {

--- a/src/utils/appHelpers.ts
+++ b/src/utils/appHelpers.ts
@@ -41,10 +41,13 @@ export function getRegisteredDeviceDisplayName(device: {
 }
 
 const DEVICE_ID_PATTERN = /^DeviceId\("(.+)"\)$/;
-const LOW_BATTERY_THRESHOLD = 20;
 
-export function mapIsLowBattery(batteryInfos: BatteryInfo[]) {
-	return batteryInfos.map((info) => info.battery_level !== null ? info.battery_level <= LOW_BATTERY_THRESHOLD : false);
+export function mapIsLowBattery(batteryInfos: BatteryInfo[], threshold: number) {
+	return batteryInfos.map((info) => info.battery_level !== null ? info.battery_level <= threshold : false);
+}
+
+export function mapIsHighBattery(batteryInfos: BatteryInfo[], threshold: number) {
+	return batteryInfos.map((info) => info.battery_level !== null ? info.battery_level >= threshold : false);
 }
 
 export function upsertBatteryInfo(batteryInfos: BatteryInfo[], nextInfo: BatteryInfo): BatteryInfo[] {

--- a/src/utils/batteryEdgeNotification.ts
+++ b/src/utils/batteryEdgeNotification.ts
@@ -30,7 +30,8 @@ export function notifyBatteryEdgeTransitions({
 		notificationType: NotificationType,
 		prev: boolean[],
 		curr: boolean[],
-		label: string,
+		verb: string,
+		threshold: number,
 	) => {
 		if (!pushNotification || !pushNotificationWhen[notificationType]) {
 			return;
@@ -40,12 +41,12 @@ export function notifyBatteryEdgeTransitions({
 			const suffix = newBatteryInfos.length >= 2
 				? ' ' + (newBatteryInfos[i].user_description ?? 'Central')
 				: '';
-			const message = `${deviceDisplayName}${suffix} has ${label} battery.`;
+			const message = `${deviceDisplayName}${suffix} battery ${verb} ${threshold}%.`;
 			fireAndForget(
 				sendNotification(message),
-				`Failed to send ${label} battery notification for ${deviceId}`,
+				`Failed to send battery notification for ${deviceId}`,
 			);
-			logger.info(`${deviceDisplayName} has ${label} battery.`);
+			logger.info(message);
 		}
 	};
 
@@ -53,12 +54,14 @@ export function notifyBatteryEdgeTransitions({
 		NotificationType.LowBattery,
 		mapIsLowBattery(prevBatteryInfos, lowBatteryThreshold),
 		mapIsLowBattery(newBatteryInfos, lowBatteryThreshold),
-		'low',
+		'dropped below',
+		lowBatteryThreshold,
 	);
 	notify(
 		NotificationType.HighBattery,
 		mapIsHighBattery(prevBatteryInfos, highBatteryThreshold),
 		mapIsHighBattery(newBatteryInfos, highBatteryThreshold),
-		'high',
+		'reached',
+		highBatteryThreshold,
 	);
 }

--- a/src/utils/batteryEdgeNotification.ts
+++ b/src/utils/batteryEdgeNotification.ts
@@ -1,0 +1,64 @@
+import { sendNotification } from "@/utils/notification";
+import { fireAndForget } from "@/utils/common";
+import { logger } from "@/utils/log";
+import { NotificationType } from "@/utils/config";
+import { mapIsLowBattery, mapIsHighBattery } from "@/utils/appHelpers";
+import type { BatteryInfo } from "@/utils/ble";
+
+interface NotifyBatteryEdgeTransitionsParams {
+	deviceDisplayName: string;
+	deviceId: string;
+	prevBatteryInfos: BatteryInfo[];
+	newBatteryInfos: BatteryInfo[];
+	lowBatteryThreshold: number;
+	highBatteryThreshold: number;
+	pushNotification: boolean;
+	pushNotificationWhen: Record<NotificationType, boolean>;
+}
+
+export function notifyBatteryEdgeTransitions({
+	deviceDisplayName,
+	deviceId,
+	prevBatteryInfos,
+	newBatteryInfos,
+	lowBatteryThreshold,
+	highBatteryThreshold,
+	pushNotification,
+	pushNotificationWhen,
+}: NotifyBatteryEdgeTransitionsParams) {
+	const notify = (
+		notificationType: NotificationType,
+		prev: boolean[],
+		curr: boolean[],
+		label: string,
+	) => {
+		if (!pushNotification || !pushNotificationWhen[notificationType]) {
+			return;
+		}
+		for (let i = 0; i < curr.length && i < prev.length; i++) {
+			if (prev[i] || !curr[i]) continue;
+			const suffix = newBatteryInfos.length >= 2
+				? ' ' + (newBatteryInfos[i].user_description ?? 'Central')
+				: '';
+			const message = `${deviceDisplayName}${suffix} has ${label} battery.`;
+			fireAndForget(
+				sendNotification(message),
+				`Failed to send ${label} battery notification for ${deviceId}`,
+			);
+			logger.info(`${deviceDisplayName} has ${label} battery.`);
+		}
+	};
+
+	notify(
+		NotificationType.LowBattery,
+		mapIsLowBattery(prevBatteryInfos, lowBatteryThreshold),
+		mapIsLowBattery(newBatteryInfos, lowBatteryThreshold),
+		'low',
+	);
+	notify(
+		NotificationType.HighBattery,
+		mapIsHighBattery(prevBatteryInfos, highBatteryThreshold),
+		mapIsHighBattery(newBatteryInfos, highBatteryThreshold),
+		'high',
+	);
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -6,9 +6,13 @@ import { logger } from './log';
 
 export enum NotificationType {
 	LowBattery = 'low_battery',
+	HighBattery = 'high_battery',
 	Disconnected = 'disconnected',
 	Connected = 'connected',
 }
+
+export const MIN_BATTERY_THRESHOLD = 1;
+export const MAX_BATTERY_THRESHOLD = 99;
 
 export enum TrayIconComponent {
 	AppIcon = 'appIcon',
@@ -27,6 +31,8 @@ export type Config = {
 	autoCollapseDisconnectedDevices: boolean;
 	pushNotification: boolean;
 	pushNotificationWhen: Record<NotificationType, boolean>;
+	lowBatteryThreshold: number;
+	highBatteryThreshold: number;
 	manualWindowPositioning: boolean;
 	windowPosition: {
 		x: number;
@@ -46,9 +52,12 @@ export const defaultConfig: Config = {
 	pushNotification: false,
 	pushNotificationWhen: {
 		[NotificationType.LowBattery]: true,
+		[NotificationType.HighBattery]: false,
 		[NotificationType.Connected]: true,
 		[NotificationType.Disconnected]: true,
 	},
+	lowBatteryThreshold: 20,
+	highBatteryThreshold: 95,
 	manualWindowPositioning: false,
 	windowPosition: {
 		x: 0,
@@ -74,13 +83,53 @@ async function getConfigStore() {
 	return configStoreInstance;
 }
 
+interface ClampBatteryThresholdBounds {
+	min?: number;
+	max?: number;
+}
+
+export function clampBatteryThreshold(
+	value: number,
+	fallback: number,
+	bounds: ClampBatteryThresholdBounds = {},
+): number {
+	if (!Number.isFinite(value)) return fallback;
+	const min = bounds.min ?? MIN_BATTERY_THRESHOLD;
+	const max = bounds.max ?? MAX_BATTERY_THRESHOLD;
+	const rounded = Math.round(value);
+	if (rounded < min) return min;
+	if (rounded > max) return max;
+	return rounded;
+}
+
 export async function loadSavedConfig(): Promise<Config> {
-	const config = await getConfigStore().then((store: Store) => store.get<Config>('config'));
+	const config = await getConfigStore().then((store: Store) => store.get<Partial<Config>>('config'));
 	logger.info(`Loaded config: ${JSON.stringify(config, null, 4)}`);
-	return {
+	const merged: Config = {
 		...defaultConfig,
 		...config,
+		pushNotificationWhen: {
+			...defaultConfig.pushNotificationWhen,
+			...(config?.pushNotificationWhen ?? {}),
+		},
+		windowPosition: {
+			...defaultConfig.windowPosition,
+			...(config?.windowPosition ?? {}),
+		},
 	};
+	const candidateLow = clampBatteryThreshold(
+		merged.lowBatteryThreshold,
+		defaultConfig.lowBatteryThreshold,
+		{ max: MAX_BATTERY_THRESHOLD - 1 },
+	);
+	const candidateHigh = clampBatteryThreshold(
+		merged.highBatteryThreshold,
+		defaultConfig.highBatteryThreshold,
+	);
+	const hasValidOrdering = candidateLow < candidateHigh;
+	const lowBatteryThreshold = hasValidOrdering ? candidateLow : defaultConfig.lowBatteryThreshold;
+	const highBatteryThreshold = hasValidOrdering ? candidateHigh : defaultConfig.highBatteryThreshold;
+	return { ...merged, lowBatteryThreshold, highBatteryThreshold };
 };
 
 export async function setConfig(config: Config) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -57,7 +57,7 @@ export const defaultConfig: Config = {
 		[NotificationType.Disconnected]: true,
 	},
 	lowBatteryThreshold: 20,
-	highBatteryThreshold: 95,
+	highBatteryThreshold: 80,
 	manualWindowPositioning: false,
 	windowPosition: {
 		x: 0,


### PR DESCRIPTION
## Summary
- Add customizable low/high battery notification thresholds (default: low ≤ 20%, high ≥ 95%)
- Add high battery notification type so users can be alerted when battery is fully charged
- Threshold inputs in Settings UI with validation and clamping
- Extract edge-transition notification logic into `batteryEdgeNotification.ts`
- Include threshold value in notification messages for clarity

Closes #80

## Test plan
- [ ] Verify default thresholds (low: 20%, high: 95%) work on fresh install
- [x] Change low/high thresholds in Settings and confirm values persist across restart
- [x] Confirm low battery notification fires when level drops below custom threshold
- [x] Confirm high battery notification fires when level reaches custom threshold
- [x] Verify threshold inputs are disabled when parent notification toggle is off
- [x] Verify low threshold cannot exceed high threshold and vice versa
- [x] `bun run test`  pass