### PR TITLE
feat(integration): publish battery-state snapshot file

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ You can manually move the window to the correct position to address this issue.
 
 See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for environment setup, build commands, and running tests.
 
+See [docs/EXTERNAL_INTEGRATION.md](docs/EXTERNAL_INTEGRATION.md) for the external battery snapshot file API.
+
 ## References
 
 Implementation and discussion for split battery reporting over BLE GATT:

--- a/docs/EXTERNAL_INTEGRATION.md
+++ b/docs/EXTERNAL_INTEGRATION.md
@@ -1,0 +1,104 @@
+# External battery snapshot
+
+zmk-battery-center publishes cached battery state for local integrations. Consumers read the snapshot file only. The app does not open an HTTP server, socket, D-Bus service, named pipe, or WebSocket.
+
+## Path
+
+Production files are stored in the app data directory:
+
+- Windows: `%APPDATA%\com.zmk-battery-center.app\external`
+- macOS: `~/Library/Application Support/com.zmk-battery-center.app/external`
+- Linux: `$XDG_DATA_HOME/com.zmk-battery-center.app/external`, or `~/.local/share/com.zmk-battery-center.app/external` when `XDG_DATA_HOME` is unset
+
+Debug builds use `<repo>/.dev-data/external`, unless `ZMK_BATTERY_CENTER_DATA_DIR` is set. Relative values are resolved from the repository root.
+
+The directory is created on the first publish. Unix builds use mode `0700` for the directory and `0600` for files. Windows uses the parent directory ACL inheritance.
+
+## `battery-state-v1.json`
+
+This is the common snapshot consumed by file-based integrations.
+
+```json
+{
+  "schemaVersion": 1,
+  "revision": 12,
+  "generatedAtUnixMs": 1786060800000,
+  "devices": [
+    {
+      "id": "raw-platform-ble-id",
+      "key": "device7261772d706c6174666f726d2d626c652d6964",
+      "name": "Corne",
+      "displayName": "Work keyboard",
+      "connectionStatus": "connected",
+      "connectionObservedAtUnixMs": 1786060799000,
+      "batteryParts": [
+        {
+          "id": "central",
+          "sourceDescription": null,
+          "displayName": "Central",
+          "levelPercent": 87,
+          "observedAtUnixMs": 1786060799000,
+          "valueStatus": "current"
+        },
+        {
+          "id": "part5065726970686572616c",
+          "sourceDescription": "Peripheral",
+          "displayName": "Right hand",
+          "levelPercent": 64,
+          "observedAtUnixMs": 1786060700000,
+          "valueStatus": "stale"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Field definitions
+
+- `schemaVersion`: fixed at `1`. Breaking changes use a new v2 filename.
+- `revision`: monotonically increasing per successful publish in one app process. Values may be skipped after a partial write failure, but a revision is never reused. Restart continuity is not guaranteed.
+- `generatedAtUnixMs`: the UTC time at which the snapshot was generated. It is not a battery observation time.
+- `device.id`: the raw platform BLE ID. Consumers must not depend on its syntax.
+- `device.key`: `device` followed by the lowercase hexadecimal UTF-8 bytes of `device.id`.
+- `name`: the BLE-advertised device name.
+- `displayName`: the user-defined name, or `name` when no custom name is set.
+- `connectionStatus`: `unknown`, `connected`, or `disconnected`. This mirrors the device connection state used by the zmk-battery-center UI and does not necessarily represent the instantaneous OS-level BLE link state. A device loaded from storage is `unknown` until its state is checked.
+- `connectionObservedAtUnixMs`: the last time the UI connection state was observed, or `null` when it is unknown.
+- `batteryParts[].id`: `central` when there is no GATT User Description, otherwise `part` followed by lowercase hexadecimal UTF-8 bytes of the description.
+- `sourceDescription`: the GATT User Description, or `null`.
+- `batteryParts[].displayName`: the custom part label, or the source description, or `Central`.
+- `levelPercent`: an integer from `0` through `100`, or `null`.
+- `observedAtUnixMs`: the last successful observation time for the level. Reusing a last-known value does not change it.
+- `valueStatus`: `current`, `stale`, or `unavailable`. Numeric values are stale when disconnected, unknown, or the latest read did not succeed. A missing numeric value is unavailable. This describes freshness at `generatedAtUnixMs`; it does not indicate that zmk-battery-center is currently running. The last snapshot remains on disk after the app exits.
+
+## Atomic access
+
+The producer writes complete JSON to a same-directory temporary file, flushes and syncs it, then atomically replaces the target. It never truncates a target in place or deletes the target before replacement. Consumers should keep the last-good document when a read observes invalid or incomplete content.
+
+## Integrations
+
+`battery-state-v1.json` is a generic snapshot API intended for use by external tools and adapters.
+
+### Available integration
+
+#### RunCat Neo
+
+[zmk-battery-center-runcat-adapter](https://github.com/kot149/zmk-battery-center-runcat-adapter) is a separate adapter that converts `battery-state-v1.json` into the Custom Metrics JSON format supported by RunCat Neo.
+
+See the adapter repository for installation and configuration instructions.
+
+### Building other integrations
+
+Integrations for other applications are not provided by zmk-battery-center. They can be implemented by reading and monitoring `battery-state-v1.json` directly.
+
+For example:
+
+* **TrafficMonitor:** A plugin could read the snapshot from `DataRequired()` and cache the values for `GetItemValueText()`. File I/O and BLE operations should not be performed from `GetItemValueText()`.
+* **GNOME Shell:** An extension could monitor `battery-state-v1.json` with `GFileMonitor` and reload the complete document when the file is replaced.
+
+These are implementation examples only; zmk-battery-center does not include TrafficMonitor or GNOME Shell integrations.
+
+## Compatibility
+
+Version 1 fields must not be deleted, renamed, or given a different meaning. Optional fields may be added. A breaking change requires a new v2 filename.

--- a/src-tauri/src/external_integration.rs
+++ b/src-tauri/src/external_integration.rs
@@ -1,0 +1,283 @@
+use serde::{Deserialize, Serialize};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tauri::{AppHandle, Manager, State};
+use tokio::sync::Mutex;
+
+const EXTERNAL_DIR_NAME: &str = "external";
+const BATTERY_STATE_FILENAME: &str = "battery-state-v1.json";
+
+#[cfg(debug_assertions)]
+const DATA_DIR_ENV: &str = "ZMK_BATTERY_CENTER_DATA_DIR";
+#[cfg(debug_assertions)]
+const DEV_DATA_DIR: &str = ".dev-data";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalBatteryPartPayload {
+    pub id: String,
+    pub source_description: Option<String>,
+    pub display_name: String,
+    pub level_percent: Option<u8>,
+    pub observed_at_unix_ms: Option<u64>,
+    pub value_status: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalBatteryDevicePayload {
+    pub id: String,
+    pub key: String,
+    pub name: String,
+    pub display_name: String,
+    pub connection_status: String,
+    pub connection_observed_at_unix_ms: Option<u64>,
+    pub battery_parts: Vec<ExternalBatteryPartPayload>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BatterySnapshot {
+    schema_version: u8,
+    revision: u64,
+    generated_at_unix_ms: u64,
+    devices: Vec<ExternalBatteryDevicePayload>,
+}
+
+#[derive(Clone, Default)]
+struct ExternalIntegrationInner {
+    current_source_generation: u64,
+    current_source_revision: u64,
+    next_source_generation: u64,
+    public_revision: u64,
+}
+
+#[derive(Clone, Default)]
+pub struct ExternalIntegrationState {
+    inner: Arc<Mutex<ExternalIntegrationInner>>,
+}
+
+fn unix_now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(debug_assertions)]
+fn resolve_debug_external_dir(
+    manifest_dir: Option<&str>,
+    env_dir: Option<&str>,
+) -> Option<PathBuf> {
+    let manifest_dir = manifest_dir?;
+    let manifest_path = PathBuf::from(manifest_dir);
+    let project_root = manifest_path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| manifest_path.clone());
+    let base = match env_dir {
+        Some(dir) => {
+            let path = PathBuf::from(dir);
+            if path.is_absolute() {
+                path
+            } else {
+                project_root.join(path)
+            }
+        }
+        None => project_root.join(DEV_DATA_DIR),
+    };
+    Some(base.join(EXTERNAL_DIR_NAME))
+}
+
+pub fn resolve_external_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    #[cfg(debug_assertions)]
+    {
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").ok();
+        let env_dir = std::env::var(DATA_DIR_ENV).ok();
+        if let Some(path) = resolve_debug_external_dir(manifest_dir.as_deref(), env_dir.as_deref())
+        {
+            return Ok(path);
+        }
+    }
+
+    app.path()
+        .app_data_dir()
+        .map(|path| path.join(EXTERNAL_DIR_NAME))
+        .map_err(|error| error.to_string())
+}
+
+fn ensure_external_dir(path: &Path) -> Result<(), String> {
+    fs::create_dir_all(path).map_err(|error| error.to_string())?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+            .map_err(|error| error.to_string())?;
+    }
+    Ok(())
+}
+
+pub fn write_json_atomically<T: Serialize>(path: &Path, value: &T) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "Target path has no parent".to_string())?;
+    ensure_external_dir(parent)?;
+    let filename = path
+        .file_name()
+        .ok_or_else(|| "Target path has no filename".to_string())?
+        .to_string_lossy();
+    let temp_path = parent.join(format!(".{filename}.tmp"));
+    let _ = fs::remove_file(&temp_path);
+
+    let write_result = (|| -> Result<(), String> {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&temp_path)
+            .map_err(|error| error.to_string())?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&temp_path, fs::Permissions::from_mode(0o600))
+                .map_err(|error| error.to_string())?;
+        }
+        serde_json::to_writer_pretty(&mut file, value).map_err(|error| error.to_string())?;
+        file.write_all(b"\n").map_err(|error| error.to_string())?;
+        file.flush().map_err(|error| error.to_string())?;
+        file.sync_all().map_err(|error| error.to_string())?;
+        Ok(())
+    })();
+
+    if let Err(error) = write_result {
+        let _ = fs::remove_file(&temp_path);
+        return Err(error);
+    }
+
+    let rename_result = (0..3).find_map(|attempt| match fs::rename(&temp_path, path) {
+        Ok(()) => Some(Ok(())),
+        Err(_error) if attempt < 2 => {
+            std::thread::sleep(Duration::from_millis(if attempt == 0 { 20 } else { 50 }));
+            None
+        }
+        Err(error) => Some(Err(error.to_string())),
+    });
+
+    match rename_result {
+        Some(Ok(())) => Ok(()),
+        Some(Err(error)) => {
+            let _ = fs::remove_file(&temp_path);
+            Err(error)
+        }
+        None => {
+            let _ = fs::remove_file(&temp_path);
+            Err("Atomic rename failed".to_string())
+        }
+    }
+}
+
+fn is_stale_source_publish(
+    inner: &ExternalIntegrationInner,
+    source_generation: u64,
+    source_revision: u64,
+) -> bool {
+    source_generation != inner.current_source_generation
+        || source_revision < inner.current_source_revision
+}
+
+#[tauri::command]
+pub async fn start_external_battery_source_session(
+    state: State<'_, ExternalIntegrationState>,
+) -> Result<u64, String> {
+    let mut inner = state.inner.lock().await;
+    inner.next_source_generation = inner.next_source_generation.saturating_add(1);
+    inner.current_source_generation = inner.next_source_generation;
+    inner.current_source_revision = 0;
+    Ok(inner.current_source_generation)
+}
+
+#[tauri::command]
+pub async fn publish_external_battery_snapshot(
+    app: AppHandle,
+    state: State<'_, ExternalIntegrationState>,
+    source_generation: u64,
+    source_revision: u64,
+    devices: Vec<ExternalBatteryDevicePayload>,
+) -> Result<(), String> {
+    let external_dir = resolve_external_dir(&app)?;
+    let mut inner = state.inner.lock().await;
+    if is_stale_source_publish(&inner, source_generation, source_revision) {
+        return Ok(());
+    }
+
+    inner.public_revision = inner.public_revision.saturating_add(1);
+    let snapshot = BatterySnapshot {
+        schema_version: 1,
+        revision: inner.public_revision,
+        generated_at_unix_ms: unix_now_ms(),
+        devices,
+    };
+    write_json_atomically(&external_dir.join(BATTERY_STATE_FILENAME), &snapshot)?;
+    inner.current_source_revision = source_revision;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn stable_debug_path_uses_external_subdirectory() {
+        let path =
+            resolve_debug_external_dir(Some("/repo/src-tauri"), Some("custom-data")).expect("path");
+        assert_eq!(path, PathBuf::from("/repo/custom-data/external"));
+    }
+
+    #[test]
+    fn stable_debug_path_uses_default_directory() {
+        let path = resolve_debug_external_dir(Some("/repo/src-tauri"), None).expect("path");
+        assert_eq!(path, PathBuf::from("/repo/.dev-data/external"));
+    }
+
+    #[test]
+    fn newer_source_generation_accepts_a_reset_revision() {
+        let mut inner = ExternalIntegrationInner {
+            current_source_generation: 1,
+            current_source_revision: 100,
+            next_source_generation: 1,
+            public_revision: 0,
+        };
+
+        assert!(is_stale_source_publish(&inner, 1, 99));
+        assert!(!is_stale_source_publish(&inner, 1, 100));
+
+        inner.current_source_generation = 2;
+        inner.current_source_revision = 0;
+        assert!(is_stale_source_publish(&inner, 1, 101));
+        assert!(!is_stale_source_publish(&inner, 2, 1));
+    }
+
+    #[test]
+    fn atomic_writer_creates_and_overwrites_strict_json() {
+        let dir = tempdir().expect("create temp dir");
+        let path = dir.path().join(BATTERY_STATE_FILENAME);
+        write_json_atomically(&path, &serde_json::json!({ "unicode": "キーボード" }))
+            .expect("write");
+        assert_eq!(
+            fs::read_to_string(&path).expect("read"),
+            "{\n  \"unicode\": \"キーボード\"\n}\n"
+        );
+        write_json_atomically(&path, &serde_json::json!({ "revision": 2 })).expect("overwrite");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).expect("read")).expect("strict JSON");
+        assert_eq!(parsed["revision"], 2);
+        assert!(!dir
+            .path()
+            .join(format!(".{BATTERY_STATE_FILENAME}.tmp"))
+            .exists());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ use tauri_plugin_autostart::MacosLauncher;
 
 mod ble;
 mod common;
+mod external_integration;
 mod history;
 mod licenses;
 mod storage;
@@ -71,6 +72,7 @@ pub fn run() {
         .plugin(tauri_plugin_single_instance::init(|_, _, _| {}))
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_positioner::init())
+        .manage(external_integration::ExternalIntegrationState::default())
         .invoke_handler(tauri::generate_handler![
             common::exit_app,
             ble::list_battery_devices,
@@ -78,6 +80,8 @@ pub fn run() {
             ble::start_battery_notification_monitor,
             ble::stop_battery_notification_monitor,
             ble::stop_all_battery_monitors,
+            external_integration::start_external_battery_source_session,
+            external_integration::publish_external_battery_snapshot,
             window::get_windows_text_scale_factor,
             licenses::get_licenses,
             storage::get_dev_store_path,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,8 @@ import { useTrayEvents } from "@/hooks/useTrayEvents";
 import { emit, listen } from '@tauri-apps/api/event';
 import { recordBatteryReadings } from '@/utils/batteryHistory';
 import {
+	annotateBatteryInfosFromRead,
+	markBatteryInfosReadFailed,
 	upsertBatteryInfo,
 	getRegisteredDeviceDisplayName,
 	type RegisteredDevice,
@@ -42,6 +44,7 @@ import { syncTrayBatteryIcon } from "@/utils/trayBatteryIcon";
 import { useRegisteredDevices, collapseIfDisconnected, expandIfConnected } from "@/hooks/useRegisteredDevices";
 import { useNotificationMonitors } from "@/hooks/useNotificationMonitors";
 import { useBatteryPolling } from "@/hooks/useBatteryPolling";
+import { useExternalBatteryIntegration } from "@/hooks/useExternalBatteryIntegration";
 
 export type { RegisteredDevice };
 
@@ -67,6 +70,7 @@ function App() {
 		registeredDeviceIds,
 		registeredDeviceIdsKey,
 		commitRegisteredDevices,
+		getRegisteredDevicesSnapshot,
 		setRegisteredDevicesForPanel,
 	} = useRegisteredDevices();
 
@@ -186,15 +190,20 @@ function App() {
 				? await startBatteryNotificationMonitor(id)
 				: await getBatteryInfo(id);
 			const infoArray = Array.isArray(info) ? info : [info];
+			const now = Date.now();
+			const annotatedInfos = annotateBatteryInfosFromRead(infoArray, now);
 			if (isNotificationMonitorMode) {
 				activeNotificationMonitorsRef.current.add(id);
 			}
+			const isDisconnected = isNotificationMonitorMode && annotatedInfos.length === 0;
 			const newDevice: RegisteredDevice = {
 				id: device.id,
 				name: device.name,
-				batteryInfos: infoArray,
-				isDisconnected: isNotificationMonitorMode ? infoArray.length === 0 : false,
-				isCollapsed: isNotificationMonitorMode && infoArray.length === 0 && config.autoCollapseDisconnectedDevices,
+				batteryInfos: annotatedInfos,
+				isDisconnected,
+				isCollapsed: isDisconnected && config.autoCollapseDisconnectedDevices,
+				connectionStatusKnown: true,
+				connectionObservedAtUnixMs: now,
 			};
 			commitRegisteredDevices(prev => [...prev, newDevice]);
 			handleCloseModal();
@@ -227,6 +236,12 @@ function App() {
 		registeredDeviceIdsKey,
 		autoCollapseDisconnectedDevicesRef,
 		commitRegisteredDevices,
+	});
+
+	useExternalBatteryIntegration({
+		isDeviceLoaded,
+		registeredDevices,
+		getRegisteredDevicesSnapshot,
 	});
 
 	const handleCloseModal = () => {
@@ -291,9 +306,11 @@ function App() {
 
 			// Side effects stay outside the state updater: React may invoke
 			// updater recipes more than once (StrictMode, concurrent replays).
-			recordBatteryReadings(device, [payload.battery_info]);
+			const now = Date.now();
+			const annotatedInfo = annotateBatteryInfosFromRead([payload.battery_info], now)[0];
+			recordBatteryReadings(device, [annotatedInfo]);
 
-			const newBatteryInfos = upsertBatteryInfo(device.batteryInfos, payload.battery_info);
+			const newBatteryInfos = upsertBatteryInfo(device.batteryInfos, annotatedInfo);
 			notifyBatteryEdgeTransitions({
 				deviceDisplayName: getRegisteredDeviceDisplayName(device),
 				deviceId: device.id,
@@ -310,7 +327,7 @@ function App() {
 			commitRegisteredDevices(prev => prev.map(d => d.id !== payload.id
 				? d
 				: expandIfConnected(
-					{ ...d, batteryInfos: upsertBatteryInfo(d.batteryInfos, payload.battery_info), isDisconnected: false },
+					{ ...d, batteryInfos: upsertBatteryInfo(d.batteryInfos, annotatedInfo), isDisconnected: false, connectionStatusKnown: true, connectionObservedAtUnixMs: now },
 					autoCollapseDisconnectedDevicesRef.current,
 				)));
 		});
@@ -348,6 +365,7 @@ function App() {
 		const unlistenPromise = listen<BatteryMonitorStatusEvent>("battery-monitor-status", event => {
 			const payload = event.payload;
 			let notificationMessage: string | null = null;
+			const now = Date.now();
 
 			commitRegisteredDevices(prev => prev.map(device => {
 				if (device.id !== payload.id) {
@@ -355,8 +373,12 @@ function App() {
 				}
 
 				const nextDisconnected = !payload.connected;
-				if (device.isDisconnected === nextDisconnected) {
-					return device;
+				const nextBatteryInfos = nextDisconnected
+					&& device.batteryInfos.some(info => info.last_read_succeeded === true)
+					? markBatteryInfosReadFailed(device.batteryInfos)
+					: device.batteryInfos;
+				if (device.isDisconnected === nextDisconnected && device.connectionStatusKnown === true) {
+					return { ...device, batteryInfos: nextBatteryInfos, connectionObservedAtUnixMs: now };
 				}
 
 				if (payload.connected) {
@@ -369,11 +391,11 @@ function App() {
 
 				return nextDisconnected
 					? collapseIfDisconnected(
-						{ ...device, isDisconnected: true },
+						{ ...device, batteryInfos: nextBatteryInfos, isDisconnected: true, connectionStatusKnown: true, connectionObservedAtUnixMs: now },
 						autoCollapseDisconnectedDevicesRef.current,
 					)
 					: expandIfConnected(
-						{ ...device, isDisconnected: false },
+						{ ...device, isDisconnected: false, connectionStatusKnown: true, connectionObservedAtUnixMs: now },
 						autoCollapseDisconnectedDevicesRef.current,
 					);
 			}));

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -203,6 +203,40 @@ describe("App", () => {
 		expect(screen.queryByLabelText("Disconnected")).toBeNull();
 	});
 
+	it("invalidates battery freshness when a connected device disconnects", async () => {
+		render(<App />);
+
+		await waitFor(() => expect(mockStore.get).toHaveBeenCalledWith("devices"));
+		await act(async () => {
+			resolveDeviceStoreGets([{
+				id: "kbd-1",
+				name: "MockBoard One",
+				isDisconnected: false,
+				isCollapsed: false,
+				batteryInfos: [{ battery_level: 87, user_description: "Central" }],
+			}]);
+		});
+		await waitFor(() => expect(batteryInfoNotificationHandler).toBeDefined());
+
+		await act(async () => {
+			batteryInfoNotificationHandler?.({
+				payload: {
+					id: "kbd-1",
+					battery_info: { battery_level: 87, user_description: "Central" },
+				},
+			});
+		});
+		await act(async () => {
+			monitorStatusHandler?.({ payload: { id: "kbd-1", connected: false } });
+		});
+
+		await waitFor(() => {
+			const writes = getStoreSetCalls().filter(([key]) => key === "devices");
+			const latest = writes[writes.length - 1]?.[1] as Array<{ batteryInfos: Array<{ last_read_succeeded?: boolean }> }> | undefined;
+			expect(latest?.[0]?.batteryInfos[0].last_read_succeeded).toBe(false);
+		});
+	});
+
 	it("collapses a device when it becomes disconnected and the option is enabled", async () => {
 		mockedConfig = {
 			...defaultConfig,

--- a/src/hooks/__tests__/useBatteryPolling.test.ts
+++ b/src/hooks/__tests__/useBatteryPolling.test.ts
@@ -197,11 +197,11 @@ describe("useBatteryPolling", () => {
 		});
 
 		expect(recordBatteryReadings).toHaveBeenCalledOnce();
-		expect(recordBatteryReadings).toHaveBeenCalledWith(device, fetchedInfos);
+		expect(recordBatteryReadings).toHaveBeenCalledWith(device, [expect.objectContaining(fetchedInfos[0])]);
 		expect(notifyBatteryEdgeTransitions).toHaveBeenCalledOnce();
 		expect(notifyBatteryEdgeTransitions).toHaveBeenCalledWith(expect.objectContaining({
 		deviceId: device.id,
-		newBatteryInfos: fetchedInfos,
+		newBatteryInfos: [expect.objectContaining(fetchedInfos[0])],
 	}));
 	});
 

--- a/src/hooks/__tests__/useExternalBatteryIntegration.test.ts
+++ b/src/hooks/__tests__/useExternalBatteryIntegration.test.ts
@@ -1,0 +1,133 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useExternalBatteryIntegration } from "@/hooks/useExternalBatteryIntegration";
+import type { RegisteredDevice } from "@/utils/appHelpers";
+
+const mocks = vi.hoisted(() => ({
+	buildExternalBatteryDevices: vi.fn((devices: RegisteredDevice[]) => devices.map(device => ({ id: device.id }))),
+	startExternalBatterySourceSession: vi.fn(async () => 7),
+	publishExternalBatterySnapshot: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/utils/externalBatteryIntegration", () => ({
+	buildExternalBatteryDevices: mocks.buildExternalBatteryDevices,
+	startExternalBatterySourceSession: mocks.startExternalBatterySourceSession,
+	publishExternalBatterySnapshot: mocks.publishExternalBatterySnapshot,
+}));
+
+vi.mock("@/utils/common", () => ({
+	fireAndForget: vi.fn((promise: Promise<unknown>) => {
+		void promise.catch(() => undefined);
+	}),
+}));
+
+function device(): RegisteredDevice {
+	return {
+		id: "kbd-1",
+		name: "Keyboard",
+		batteryInfos: [],
+		isDisconnected: false,
+		isCollapsed: false,
+	};
+}
+
+describe("useExternalBatteryIntegration", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("waits for device loading before publishing", async () => {
+		const snapshot = { devices: [] as RegisteredDevice[], sourceRevision: 0 };
+		const initialProps: {
+			isDeviceLoaded: boolean;
+			registeredDevices: RegisteredDevice[] | undefined;
+		} = { isDeviceLoaded: false, registeredDevices: undefined };
+		const view = renderHook(
+			({ isDeviceLoaded, registeredDevices }) => useExternalBatteryIntegration({
+				isDeviceLoaded,
+				registeredDevices,
+				getRegisteredDevicesSnapshot: () => snapshot,
+			}),
+			{ initialProps },
+		);
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(100);
+		});
+		expect(mocks.publishExternalBatterySnapshot).not.toHaveBeenCalled();
+
+		const devices = [device()];
+		snapshot.devices = devices;
+		snapshot.sourceRevision = 3;
+		view.rerender({ isDeviceLoaded: true, registeredDevices: devices });
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(75);
+		});
+
+		expect(mocks.startExternalBatterySourceSession).toHaveBeenCalledOnce();
+		expect(mocks.publishExternalBatterySnapshot).toHaveBeenCalledWith(7, 3, [{ id: "kbd-1" }]);
+	});
+
+	it("publishes the latest synchronous snapshot after device changes", async () => {
+		const firstDevice = device();
+		const snapshot = { devices: [firstDevice], sourceRevision: 1 };
+		const view = renderHook(
+			({ registeredDevices }) => useExternalBatteryIntegration({
+				isDeviceLoaded: true,
+				registeredDevices,
+				getRegisteredDevicesSnapshot: () => snapshot,
+			}),
+			{ initialProps: { registeredDevices: [firstDevice] } },
+		);
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(75);
+		});
+
+		const nextDevice = { ...firstDevice, id: "kbd-2" };
+		snapshot.devices = [nextDevice];
+		snapshot.sourceRevision = 2;
+		view.rerender({ registeredDevices: [nextDevice] });
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(75);
+		});
+
+		expect(mocks.publishExternalBatterySnapshot).toHaveBeenLastCalledWith(7, 2, [{ id: "kbd-2" }]);
+	});
+
+	it("starts a new source session after a frontend reload", async () => {
+		mocks.startExternalBatterySourceSession
+			.mockResolvedValueOnce(10)
+			.mockResolvedValueOnce(11);
+		const firstDevice = device();
+		const snapshot = { devices: [firstDevice], sourceRevision: 1 };
+		const createView = () => renderHook(
+			({ registeredDevices }) => useExternalBatteryIntegration({
+				isDeviceLoaded: true,
+				registeredDevices,
+				getRegisteredDevicesSnapshot: () => snapshot,
+			}),
+			{ initialProps: { registeredDevices: [firstDevice] } },
+		);
+
+		const firstView = createView();
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(75);
+		});
+		firstView.unmount();
+
+		const secondView = createView();
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(75);
+		});
+		secondView.unmount();
+
+		expect(mocks.startExternalBatterySourceSession).toHaveBeenCalledTimes(2);
+		expect(mocks.publishExternalBatterySnapshot).toHaveBeenNthCalledWith(1, 10, 1, [{ id: "kbd-1" }]);
+		expect(mocks.publishExternalBatterySnapshot).toHaveBeenNthCalledWith(2, 11, 1, [{ id: "kbd-1" }]);
+	});
+});

--- a/src/hooks/__tests__/useNotificationMonitors.test.ts
+++ b/src/hooks/__tests__/useNotificationMonitors.test.ts
@@ -68,6 +68,34 @@ describe("useNotificationMonitors", () => {
 		});
 	}
 
+	it("invalidates cached battery freshness when the monitor starts disconnected", async () => {
+		let devices: RegisteredDevice[] = [{
+			id: "A",
+			name: "Keyboard",
+			batteryInfos: [{
+				battery_level: 50,
+				user_description: "Central",
+				last_read_succeeded: true,
+			}],
+			isDisconnected: false,
+			isCollapsed: false,
+		}];
+		const commit = vi.fn((recipe: (current: RegisteredDevice[]) => RegisteredDevice[]) => {
+			devices = recipe(devices);
+		});
+		renderMonitors({ key: "A", commit });
+
+		await resolveStart("A", []);
+
+		await waitFor(() => {
+			expect(devices[0]).toMatchObject({
+				isDisconnected: true,
+				connectionStatusKnown: true,
+				batteryInfos: [{ battery_level: 50, last_read_succeeded: false }],
+			});
+		});
+	});
+
 	it("queues a rerendered reconciliation behind the in-flight one", async () => {
 		const view = renderMonitors({ key: "A" });
 

--- a/src/hooks/__tests__/useRegisteredDevices.test.ts
+++ b/src/hooks/__tests__/useRegisteredDevices.test.ts
@@ -1,0 +1,71 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useRegisteredDevices } from "@/hooks/useRegisteredDevices";
+import type { RegisteredDevice } from "@/utils/appHelpers";
+
+const store = {
+	get: vi.fn(),
+	set: vi.fn(async () => undefined),
+};
+
+vi.mock("@/utils/storage", () => ({
+	load: vi.fn(async () => store),
+	getStorePath: vi.fn(async (filename: string) => filename),
+}));
+
+describe("useRegisteredDevices", () => {
+	beforeEach(() => {
+		store.get.mockReset();
+		store.set.mockReset();
+		store.set.mockResolvedValue(undefined);
+		store.get.mockResolvedValue([]);
+	});
+
+	function loadedDevice(): RegisteredDevice {
+		return {
+			id: "kbd-1",
+			name: "Keyboard",
+			batteryInfos: [],
+			isDisconnected: false,
+			isCollapsed: false,
+		};
+	}
+
+	it("does not commit before loading and exposes a synchronous ref snapshot", async () => {
+		let resolveLoad!: (value: unknown) => void;
+		store.get.mockImplementation(() => new Promise(resolve => { resolveLoad = resolve; }));
+		const view = renderHook(() => useRegisteredDevices());
+		await waitFor(() => expect(store.get).toHaveBeenCalledWith("devices"));
+
+		act(() => {
+			view.result.current.commitRegisteredDevices(() => [loadedDevice()]);
+		});
+		expect(view.result.current.getRegisteredDevicesSnapshot()).toEqual({ devices: [], sourceRevision: 0 });
+
+		await act(async () => resolveLoad([]));
+		await waitFor(() => expect(view.result.current.isDeviceLoaded).toBe(true));
+		expect(view.result.current.getRegisteredDevicesSnapshot().sourceRevision).toBe(1);
+	});
+
+	it("applies synchronous commits sequentially and evaluates each recipe once", async () => {
+		await act(async () => {
+			await Promise.resolve();
+		});
+		const view = renderHook(() => useRegisteredDevices());
+		await waitFor(() => expect(view.result.current.isDeviceLoaded).toBe(true));
+		const firstRecipe = vi.fn((devices: RegisteredDevice[]) => [...devices, loadedDevice()]);
+		const secondRecipe = vi.fn((devices: RegisteredDevice[]) => [...devices, { ...loadedDevice(), id: "kbd-2" }]);
+
+		act(() => {
+			view.result.current.commitRegisteredDevices(firstRecipe);
+			view.result.current.commitRegisteredDevices(secondRecipe);
+		});
+
+		expect(firstRecipe).toHaveBeenCalledOnce();
+		expect(secondRecipe).toHaveBeenCalledOnce();
+		expect(view.result.current.getRegisteredDevicesSnapshot()).toMatchObject({
+			devices: [expect.objectContaining({ id: "kbd-1" }), expect.objectContaining({ id: "kbd-2" })],
+			sourceRevision: 3,
+		});
+	});
+});

--- a/src/hooks/useBatteryPolling.ts
+++ b/src/hooks/useBatteryPolling.ts
@@ -7,8 +7,10 @@ import { sendNotification } from "@/utils/notification";
 import { NotificationType } from "@/utils/config";
 import { notifyBatteryEdgeTransitions } from "@/utils/batteryEdgeNotification";
 import {
-	mergeBatteryInfos,
+	annotateBatteryInfosFromRead,
 	getRegisteredDeviceDisplayName,
+	markBatteryInfosReadFailed,
+	mergeBatteryInfos,
 	type RegisteredDevice,
 } from "@/utils/appHelpers";
 import { collapseIfDisconnected, expandIfConnected } from "@/hooks/useRegisteredDevices";
@@ -51,6 +53,7 @@ export function useBatteryPolling({
 	// Shared by the interval cycle and the manual reload: concurrent
 	// get_battery_info calls for one device can tear each other down.
 	const isCycleInFlightRef = useRef(false);
+
 	useEffect(() => {
 		pushNotificationRef.current = pushNotification;
 		pushNotificationWhenRef.current = pushNotificationWhen;
@@ -62,26 +65,36 @@ export function useBatteryPolling({
 
 	const updateBatteryInfo = useCallback(async (device: RegisteredDevice) => {
 		const isDisconnectedPrev = device.isDisconnected;
-
-		let attempts = 0;
 		const maxAttempts = isDisconnectedPrev ? 1 : 3;
+		let attempts = 0;
 
 		while (attempts < maxAttempts) {
 			logger.info(`Updating battery info for: ${device.id} (attempt ${attempts + 1} of ${maxAttempts})`);
 			try {
 				const info = await getBatteryInfo(device.id);
+				const now = Date.now();
 				const infoArray = Array.isArray(info) ? info : [info];
+				const annotatedInfos = annotateBatteryInfosFromRead(infoArray, now);
 				commitRegisteredDevices(prev => prev.map(d => {
 					if (d.id !== device.id) return d;
+					const batteryInfos = annotatedInfos.length > 0
+						? mergeBatteryInfos(d.batteryInfos, annotatedInfos)
+						: markBatteryInfosReadFailed(d.batteryInfos);
 					return expandIfConnected(
-						{ ...d, batteryInfos: mergeBatteryInfos(d.batteryInfos, infoArray), isDisconnected: false },
+						{
+							...d,
+							batteryInfos,
+							isDisconnected: false,
+							connectionStatusKnown: true,
+							connectionObservedAtUnixMs: now,
+						},
 						autoCollapseDisconnectedDevicesRef.current,
 					);
 				}));
 
-				recordBatteryReadings(device, infoArray);
+				recordBatteryReadings(device, annotatedInfos);
 
-				if(isDisconnectedPrev && pushNotificationRef.current && pushNotificationWhenRef.current[NotificationType.Connected]){
+				if (isDisconnectedPrev && pushNotificationRef.current && pushNotificationWhenRef.current[NotificationType.Connected]) {
 					fireAndForget(
 						sendNotification(`${getRegisteredDeviceDisplayName(device)} has been connected.`),
 						`Failed to send connected notification for ${device.id}`,
@@ -92,7 +105,7 @@ export function useBatteryPolling({
 					deviceDisplayName: getRegisteredDeviceDisplayName(device),
 					deviceId: device.id,
 					prevBatteryInfos: device.batteryInfos,
-					newBatteryInfos: infoArray,
+					newBatteryInfos: annotatedInfos,
 					batteryPartLabels: device.batteryPartLabels,
 					lowBatteryThreshold: lowBatteryThresholdRef.current,
 					ignoreZeroPercent: ignoreZeroPercentRef.current,
@@ -105,23 +118,28 @@ export function useBatteryPolling({
 			} catch {
 				attempts++;
 				if (attempts >= maxAttempts) {
+					const now = Date.now();
 					commitRegisteredDevices(prev => prev.map(d => {
-						if (d.id !== device.id) {
-							return d;
-						}
+						if (d.id !== device.id) return d;
 						return collapseIfDisconnected(
-							{ ...d, isDisconnected: true },
+							{
+								...d,
+								batteryInfos: markBatteryInfosReadFailed(d.batteryInfos),
+								isDisconnected: true,
+								connectionStatusKnown: true,
+								connectionObservedAtUnixMs: now,
+							},
 							autoCollapseDisconnectedDevicesRef.current,
 						);
 					}));
 
-					if(!isDisconnectedPrev && pushNotificationRef.current && pushNotificationWhenRef.current[NotificationType.Disconnected]){
+					if (!isDisconnectedPrev && pushNotificationRef.current && pushNotificationWhenRef.current[NotificationType.Disconnected]) {
 						fireAndForget(
 							sendNotification(`${getRegisteredDeviceDisplayName(device)} has been disconnected.`),
 							`Failed to send disconnected notification for ${device.id}`,
 						);
-						return;
 					}
+					return;
 				}
 			}
 			await sleep(500);

--- a/src/hooks/useExternalBatteryIntegration.ts
+++ b/src/hooks/useExternalBatteryIntegration.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useRef } from "react";
+import { fireAndForget } from "@/utils/common";
+import {
+	buildExternalBatteryDevices,
+	publishExternalBatterySnapshot,
+	startExternalBatterySourceSession,
+	type RegisteredDevicesSnapshot,
+} from "@/utils/externalBatteryIntegration";
+import type { RegisteredDevice } from "@/utils/appHelpers";
+
+const PUBLISH_DEBOUNCE_MS = 75;
+
+type UseExternalBatteryIntegrationOptions = {
+	isDeviceLoaded: boolean;
+	registeredDevices: RegisteredDevice[] | undefined;
+	getRegisteredDevicesSnapshot: () => RegisteredDevicesSnapshot;
+};
+
+export function useExternalBatteryIntegration({
+	isDeviceLoaded,
+	registeredDevices,
+	getRegisteredDevicesSnapshot,
+}: UseExternalBatteryIntegrationOptions) {
+	const getSnapshotRef = useRef(getRegisteredDevicesSnapshot);
+	const isDeviceLoadedRef = useRef(isDeviceLoaded);
+	const publishTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const sourceGenerationRef = useRef<number | null>(null);
+	const sourceGenerationPromiseRef = useRef<Promise<number> | null>(null);
+
+	getSnapshotRef.current = getRegisteredDevicesSnapshot;
+	isDeviceLoadedRef.current = isDeviceLoaded;
+
+	const getSourceGeneration = useCallback(() => {
+		if (sourceGenerationRef.current !== null) {
+			return Promise.resolve(sourceGenerationRef.current);
+		}
+		if (sourceGenerationPromiseRef.current !== null) {
+			return sourceGenerationPromiseRef.current;
+		}
+		const promise = startExternalBatterySourceSession().then((sourceGeneration) => {
+			sourceGenerationRef.current = sourceGeneration;
+			return sourceGeneration;
+		}).finally(() => {
+			sourceGenerationPromiseRef.current = null;
+		});
+		sourceGenerationPromiseRef.current = promise;
+		return promise;
+	}, []);
+
+	const publishSnapshot = useCallback(() => {
+		if (!isDeviceLoadedRef.current) return;
+		fireAndForget(
+			getSourceGeneration().then((sourceGeneration) => {
+				const snapshot = getSnapshotRef.current();
+				return publishExternalBatterySnapshot(
+					sourceGeneration,
+					snapshot.sourceRevision,
+					buildExternalBatteryDevices(snapshot.devices),
+				);
+			}),
+			"Failed to publish external battery snapshot",
+		);
+	}, [getSourceGeneration]);
+
+	useEffect(() => {
+		if (!isDeviceLoaded) return;
+		if (publishTimerRef.current !== null) {
+			clearTimeout(publishTimerRef.current);
+		}
+		publishTimerRef.current = setTimeout(() => {
+			publishTimerRef.current = null;
+			publishSnapshot();
+		}, PUBLISH_DEBOUNCE_MS);
+		return () => {
+			if (publishTimerRef.current !== null) {
+				clearTimeout(publishTimerRef.current);
+				publishTimerRef.current = null;
+			}
+		};
+	}, [isDeviceLoaded, registeredDevices, publishSnapshot]);
+
+	useEffect(() => () => {
+		if (publishTimerRef.current !== null) {
+			clearTimeout(publishTimerRef.current);
+		}
+	}, []);
+}

--- a/src/hooks/useNotificationMonitors.ts
+++ b/src/hooks/useNotificationMonitors.ts
@@ -6,7 +6,12 @@ import {
 } from "@/utils/ble";
 import { logger } from "@/utils/log";
 import { fireAndForget } from "@/utils/common";
-import { mergeBatteryInfos, type RegisteredDevice } from "@/utils/appHelpers";
+import {
+	annotateBatteryInfosFromRead,
+	markBatteryInfosReadFailed,
+	mergeBatteryInfos,
+	type RegisteredDevice,
+} from "@/utils/appHelpers";
 import { collapseIfDisconnected, expandIfConnected } from "@/hooks/useRegisteredDevices";
 
 interface UseNotificationMonitorsOptions {
@@ -41,8 +46,6 @@ export function useNotificationMonitors({
 		const syncNotificationMonitors = async () => {
 			if (isStale()) return; // superseded while queued behind the previous run
 			const active = activeNotificationMonitorsRef.current;
-			// Derive the desired set from the stable key so that this effect
-			// does NOT re-run when battery levels or connection status change.
 			const desiredIds = registeredDeviceIdsKey ? registeredDeviceIdsKey.split(',') : [];
 			const desired = isNotificationMonitorMode
 				? new Set(desiredIds)
@@ -70,17 +73,25 @@ export function useNotificationMonitors({
 				try {
 					const info = await startBatteryNotificationMonitor(id);
 					// The monitor IS running now; `active` must say so even if this
-					// run was superseded — the next run reconciles from true state.
+					// run was superseded. The next run reconciles from true state.
 					active.add(id);
 					if (isStale()) return;
 					const infoArray = Array.isArray(info) ? info : [info];
+					const now = Date.now();
+					const annotatedInfos = annotateBatteryInfosFromRead(infoArray, now);
 					// Empty array means the device was not connected at startup and a
 					// connection watcher was launched. Keep isDisconnected:true until
 					// the watcher emits a battery-info-notification event on connection.
-					if (infoArray.length > 0) {
+					if (annotatedInfos.length > 0) {
 						commitRegisteredDevices(prev => prev.map(device => device.id === id
 							? expandIfConnected(
-								{ ...device, batteryInfos: mergeBatteryInfos(device.batteryInfos, infoArray), isDisconnected: false },
+								{
+									...device,
+									batteryInfos: mergeBatteryInfos(device.batteryInfos, annotatedInfos),
+									isDisconnected: false,
+									connectionStatusKnown: true,
+									connectionObservedAtUnixMs: now,
+								},
 								autoCollapseDisconnectedDevicesRef.current,
 							)
 							: device
@@ -88,19 +99,32 @@ export function useNotificationMonitors({
 					} else {
 						commitRegisteredDevices(prev => prev.map(device => device.id === id
 							? collapseIfDisconnected(
-								{ ...device, isDisconnected: true },
+								{
+									...device,
+									batteryInfos: markBatteryInfosReadFailed(device.batteryInfos),
+									isDisconnected: true,
+									connectionStatusKnown: true,
+									connectionObservedAtUnixMs: now,
+								},
 								autoCollapseDisconnectedDevicesRef.current,
 							)
 							: device
 						));
 					}
 				} catch {
+					const now = Date.now();
 					commitRegisteredDevices(prev => prev.map(device => {
-						if (device.id !== id || device.isDisconnected) {
+						if (device.id !== id) {
 							return device;
 						}
 						return collapseIfDisconnected(
-							{ ...device, isDisconnected: true },
+							{
+								...device,
+								batteryInfos: markBatteryInfosReadFailed(device.batteryInfos),
+								isDisconnected: true,
+								connectionStatusKnown: true,
+								connectionObservedAtUnixMs: now,
+							},
 							autoCollapseDisconnectedDevicesRef.current,
 						);
 					}));

--- a/src/hooks/useRegisteredDevices.ts
+++ b/src/hooks/useRegisteredDevices.ts
@@ -17,12 +17,16 @@ import {
 
 const DEVICES_FILENAME = "devices.json";
 
+type RegisteredDevicesSnapshot = {
+	devices: RegisteredDevice[];
+	sourceRevision: number;
+};
+
 async function loadDevicesFromFile(): Promise<RegisteredDevice[]> {
 	const storePath = await getStorePath(DEVICES_FILENAME);
 	const deviceStore = await load(storePath, { autoSave: true, defaults: {} });
 	const raw = await deviceStore.get<unknown>("devices");
-	const devices = normalizeLoadedDevices(raw);
-	return devices;
+	return normalizeLoadedDevices(raw);
 }
 
 export function collapseIfDisconnected(device: RegisteredDevice, shouldCollapse: boolean): RegisteredDevice {
@@ -46,10 +50,9 @@ export function useRegisteredDevices() {
 		() => registeredDevices ?? [],
 		[registeredDevices],
 	);
-	const registeredDevicesRef = useRef<RegisteredDevice[]>(deviceList);
-	useEffect(() => {
-		registeredDevicesRef.current = deviceList;
-	}, [deviceList]);
+	const registeredDevicesRef = useRef<RegisteredDevice[]>([]);
+	const registeredDevicesRevisionRef = useRef(0);
+	const loadedRef = useRef(false);
 
 	const persistRegisteredDevices = useCallback(async (devices: RegisteredDevice[]) => {
 		const storePath = await getStorePath(DEVICES_FILENAME);
@@ -60,14 +63,15 @@ export function useRegisteredDevices() {
 
 	const commitRegisteredDevices = useCallback(
 		(recipe: (current: RegisteredDevice[]) => RegisteredDevice[]) => {
-			setRegisteredDevices((prev) => {
-				if (prev === undefined) {
-					return prev;
-				}
-				const next = recipe(prev);
-				fireAndForget(persistRegisteredDevices(next), "Failed to persist registered devices");
-				return next;
-			});
+			if (!loadedRef.current) {
+				return;
+			}
+			const current = registeredDevicesRef.current;
+			const next = recipe(current);
+			registeredDevicesRef.current = next;
+			registeredDevicesRevisionRef.current += 1;
+			setRegisteredDevices(next);
+			fireAndForget(persistRegisteredDevices(next), "Failed to persist registered devices");
 		},
 		[persistRegisteredDevices],
 	);
@@ -97,23 +101,31 @@ export function useRegisteredDevices() {
 		[registeredDeviceIds]
 	);
 
+	const getRegisteredDevicesSnapshot = useCallback((): RegisteredDevicesSnapshot => ({
+		devices: registeredDevicesRef.current,
+		sourceRevision: registeredDevicesRevisionRef.current,
+	}), []);
+
 	// Load saved devices
 	useEffect(() => {
 		let cancelled = false;
 		const fetchRegisteredDevices = async () => {
 			const devices = await loadDevicesFromFile();
-			if (cancelled) {
+			if (cancelled || loadedRef.current) {
 				return;
 			}
-			setRegisteredDevices((prev) => {
-				// Avoid overwriting user-visible state (e.g. after remove) when a
-				// slower load completes — common with StrictMode double-mount or
-				// store I/O contending with notification-mode persistence.
-				if (prev !== undefined) {
-					return prev;
-				}
-				return devices.map(d => ({ ...d, isDisconnected: true }));
-			});
+			// Avoid overwriting user-visible state after a slower load completes.
+			// This can happen when StrictMode starts the load effect twice.
+			const loadedDevices = devices.map(d => ({
+				...d,
+				isDisconnected: true,
+				connectionStatusKnown: false,
+				connectionObservedAtUnixMs: null,
+			}));
+			loadedRef.current = true;
+			registeredDevicesRef.current = loadedDevices;
+			registeredDevicesRevisionRef.current = 1;
+			setRegisteredDevices(loadedDevices);
 			logger.info(`Loaded saved registered devices: ${JSON.stringify(devices, null, 4)}`);
 		};
 		fireAndForget(fetchRegisteredDevices(), "Failed to load registered devices");
@@ -127,9 +139,12 @@ export function useRegisteredDevices() {
 		isDeviceLoaded,
 		deviceList,
 		registeredDevicesRef,
+		registeredDevicesRevisionRef,
+		loadedRef,
 		registeredDeviceIds,
 		registeredDeviceIdsKey,
 		commitRegisteredDevices,
 		setRegisteredDevicesForPanel,
+		getRegisteredDevicesSnapshot,
 	};
 }

--- a/src/utils/__tests__/appHelpers.test.ts
+++ b/src/utils/__tests__/appHelpers.test.ts
@@ -20,12 +20,12 @@ describe("App helpers", () => {
 				{ battery_level: 19, user_description: "Central" },
 				{ battery_level: null, user_description: "Aux" },
 			];
-			expect(mapIsLowBattery(infos, 20)).toEqual([false, true, true, false]);
+			expect(mapIsLowBattery(infos, 20)).toMatchObject([false, true, true, false]);
 		});
 
 		it("respects a custom threshold", () => {
 			const infos = [{ battery_level: 30, user_description: null }];
-			expect(mapIsLowBattery(infos, 50)).toEqual([true]);
+			expect(mapIsLowBattery(infos, 50)).toMatchObject([true]);
 		});
 	});
 
@@ -37,7 +37,7 @@ describe("App helpers", () => {
 				{ battery_level: 100, user_description: "Central" },
 				{ battery_level: null, user_description: "Aux" },
 			];
-			expect(mapIsHighBattery(infos, 95)).toEqual([false, true, true, false]);
+			expect(mapIsHighBattery(infos, 95)).toMatchObject([false, true, true, false]);
 		});
 	});
 
@@ -46,7 +46,7 @@ describe("App helpers", () => {
 			const prev = [{ battery_level: 80, user_description: "Left" }];
 			const nextInfo = { battery_level: 65, user_description: "Right" };
 
-			expect(upsertBatteryInfo(prev, nextInfo)).toEqual([
+			expect(upsertBatteryInfo(prev, nextInfo)).toMatchObject([
 				{ battery_level: 80, user_description: "Left" },
 				{ battery_level: 65, user_description: "Right" },
 			]);
@@ -56,7 +56,7 @@ describe("App helpers", () => {
 			const prev = [{ battery_level: 42, user_description: "Central" }];
 			const nextInfo = { battery_level: null, user_description: "Central" };
 
-			expect(upsertBatteryInfo(prev, nextInfo)).toEqual([
+			expect(upsertBatteryInfo(prev, nextInfo)).toMatchObject([
 				{ battery_level: 42, user_description: "Central" },
 			]);
 		});
@@ -65,7 +65,7 @@ describe("App helpers", () => {
 			const prev = [{ battery_level: 42, user_description: "Central" }];
 			const nextInfo = { battery_level: 99, user_description: "Central" };
 
-			expect(upsertBatteryInfo(prev, nextInfo)).toEqual([
+			expect(upsertBatteryInfo(prev, nextInfo)).toMatchObject([
 				{ battery_level: 99, user_description: "Central" },
 			]);
 		});
@@ -74,7 +74,7 @@ describe("App helpers", () => {
 			const prev = [{ battery_level: 10, user_description: null }];
 			const nextInfo = { battery_level: 55, user_description: null };
 
-			expect(upsertBatteryInfo(prev, nextInfo)).toEqual([{ battery_level: 55, user_description: null }]);
+			expect(upsertBatteryInfo(prev, nextInfo)).toMatchObject([{ battery_level: 55, user_description: null }]);
 		});
 	});
 
@@ -90,7 +90,7 @@ describe("App helpers", () => {
 				{ battery_level: 71, user_description: "Central" },
 			];
 
-			expect(mergeBatteryInfos(prev, next)).toEqual([
+			expect(mergeBatteryInfos(prev, next)).toMatchObject([
 				{ battery_level: 30, user_description: "Left" },
 				{ battery_level: 44, user_description: "Right" },
 				{ battery_level: 71, user_description: "Central" },
@@ -99,7 +99,7 @@ describe("App helpers", () => {
 
 		it("returns empty array when next is empty", () => {
 			const prev = [{ battery_level: 30, user_description: "Left" }];
-			expect(mergeBatteryInfos(prev, [])).toEqual([]);
+			expect(mergeBatteryInfos(prev, [])).toMatchObject([]);
 		});
 
 		it("passes through next when prev is empty and levels are null", () => {
@@ -107,7 +107,7 @@ describe("App helpers", () => {
 				{ battery_level: null, user_description: "Left" },
 				{ battery_level: 44, user_description: "Right" },
 			];
-			expect(mergeBatteryInfos([], next)).toEqual([
+			expect(mergeBatteryInfos([], next)).toMatchObject([
 				{ battery_level: null, user_description: "Left" },
 				{ battery_level: 44, user_description: "Right" },
 			]);
@@ -116,7 +116,7 @@ describe("App helpers", () => {
 		it("keeps null battery level when no matching previous entry exists", () => {
 			const prev = [{ battery_level: 30, user_description: "Left" }];
 			const next = [{ battery_level: null, user_description: "Right" }];
-			expect(mergeBatteryInfos(prev, next)).toEqual([
+			expect(mergeBatteryInfos(prev, next)).toMatchObject([
 				{ battery_level: null, user_description: "Right" },
 			]);
 		});
@@ -136,7 +136,7 @@ describe("App helpers", () => {
 				},
 			];
 
-			expect(normalizeLoadedDevices(raw)).toEqual([
+			expect(normalizeLoadedDevices(raw)).toMatchObject([
 				{
 					id: "abc-123",
 					name: "My Keyboard",
@@ -151,12 +151,12 @@ describe("App helpers", () => {
 		});
 
 		it("returns empty array for non-array input", () => {
-			expect(normalizeLoadedDevices({ invalid: true })).toEqual([]);
+			expect(normalizeLoadedDevices({ invalid: true })).toMatchObject([]);
 		});
 
 		it("uses empty batteryInfos when field is missing", () => {
 			const raw = [{ id: "dev-1", name: "Keyboard", isDisconnected: false }];
-			expect(normalizeLoadedDevices(raw)).toEqual([
+			expect(normalizeLoadedDevices(raw)).toMatchObject([
 				{
 					id: "dev-1",
 					name: "Keyboard",
@@ -169,7 +169,7 @@ describe("App helpers", () => {
 
 		it("returns empty id and name strings when not strings", () => {
 			const raw = [{ id: 123, name: null, batteryInfos: [] }];
-			expect(normalizeLoadedDevices(raw)).toEqual([
+			expect(normalizeLoadedDevices(raw)).toMatchObject([
 				{
 					id: "",
 					name: "",
@@ -189,7 +189,7 @@ describe("App helpers", () => {
 					batteryInfos: [],
 				},
 			];
-			expect(normalizeLoadedDevices(raw)).toEqual([
+			expect(normalizeLoadedDevices(raw)).toMatchObject([
 				{
 					id: "plain-id",
 					name: "Plain Name",
@@ -206,7 +206,7 @@ describe("App helpers", () => {
 					{ id: "a", name: "A", batteryInfos: [], isDisconnected: false },
 					{ id: "b", name: "B", batteryInfos: [] },
 				]),
-			).toEqual([
+			).toMatchObject([
 				{ id: "a", name: "A", isDisconnected: false, isCollapsed: false, batteryInfos: [] },
 				{ id: "b", name: "B", isDisconnected: false, isCollapsed: false, batteryInfos: [] },
 			]);
@@ -224,7 +224,7 @@ describe("App helpers", () => {
 				},
 			];
 
-			expect(normalizeLoadedDevices(raw)).toEqual([
+			expect(normalizeLoadedDevices(raw)).toMatchObject([
 				{
 					id: "dev-1",
 					name: "Keyboard",
@@ -248,7 +248,7 @@ describe("App helpers", () => {
 				},
 			];
 
-			expect(normalizeLoadedDevices(raw)).toEqual([
+			expect(normalizeLoadedDevices(raw)).toMatchObject([
 				{
 					id: "dev-1",
 					name: "Keyboard",
@@ -270,7 +270,7 @@ describe("App helpers", () => {
 				},
 			];
 
-			expect(normalizeLoadedDevices(raw)).toEqual([
+			expect(normalizeLoadedDevices(raw)).toMatchObject([
 				{
 					id: "dev-1",
 					name: "Keyboard",
@@ -291,7 +291,7 @@ describe("App helpers", () => {
 				},
 			];
 
-			expect(normalizeLoadedDevices(raw)).toEqual([
+			expect(normalizeLoadedDevices(raw)).toMatchObject([
 				{
 					id: "dev-1",
 					name: "Keyboard",

--- a/src/utils/__tests__/externalBatteryIntegration.test.ts
+++ b/src/utils/__tests__/externalBatteryIntegration.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildExternalBatteryDevices,
+	getExternalBatteryPartId,
+	toStableExternalKey,
+} from "@/utils/externalBatteryIntegration";
+import type { RegisteredDevice } from "@/utils/appHelpers";
+
+function device(overrides: Partial<RegisteredDevice> = {}): RegisteredDevice {
+	return {
+		id: "kbd-1",
+		name: "Corne",
+		batteryInfos: [{
+			battery_level: 87,
+			user_description: null,
+			observed_at_unix_ms: 100,
+			last_read_succeeded: true,
+		}],
+		isDisconnected: false,
+		isCollapsed: false,
+		connectionStatusKnown: true,
+		connectionObservedAtUnixMs: 110,
+		...overrides,
+	};
+}
+
+describe("external battery integration", () => {
+	it("encodes stable keys from UTF-8 bytes", () => {
+		expect(toStableExternalKey("device", "キーボード")).toBe("devicee382ade383bce3839ce383bce38389");
+		expect(getExternalBatteryPartId("Peripheral")).toBe("part5065726970686572616c");
+		expect(getExternalBatteryPartId(null)).toBe("central");
+	});
+
+	it("maps custom display names and preserves ordering", () => {
+		const input = [device({
+			displayName: "Work keyboard",
+			batteryPartLabels: { Central: "Main" },
+			batteryInfos: [
+				{ battery_level: 0, user_description: null, observed_at_unix_ms: 1, last_read_succeeded: true },
+				{ battery_level: 100, user_description: "Peripheral", observed_at_unix_ms: 2, last_read_succeeded: true },
+			],
+		})];
+		const mapped = buildExternalBatteryDevices(input);
+		expect(mapped[0]).toMatchObject({
+			key: "device6b62642d31",
+			displayName: "Work keyboard",
+			connectionStatus: "connected",
+			connectionObservedAtUnixMs: 110,
+		});
+		expect(mapped[0].batteryParts).toEqual([
+			expect.objectContaining({ id: "central", displayName: "Main", levelPercent: 0, valueStatus: "current" }),
+			expect.objectContaining({ id: "part5065726970686572616c", displayName: "Peripheral", levelPercent: 100, valueStatus: "current" }),
+		]);
+	});
+
+	it.each([
+		[false, undefined, "unknown"],
+		[true, true, "disconnected"],
+		[true, false, "connected"],
+	] as const)("maps connection state", (knownMarker, disconnected, expected) => {
+		const mapped = buildExternalBatteryDevices([device({
+			connectionStatusKnown: knownMarker,
+			isDisconnected: disconnected ?? false,
+		})]);
+		expect(mapped[0].connectionStatus).toBe(expected);
+		expect(mapped[0].connectionObservedAtUnixMs).toBe(expected === "unknown" ? null : 110);
+	});
+
+	it("distinguishes current, stale, and unavailable values", () => {
+		const mapped = buildExternalBatteryDevices([device({
+			batteryInfos: [
+				{ battery_level: 50, user_description: null, last_read_succeeded: true, observed_at_unix_ms: 1 },
+				{ battery_level: 60, user_description: "Left", last_read_succeeded: false, observed_at_unix_ms: 2 },
+				{ battery_level: null, user_description: "Right", last_read_succeeded: false, observed_at_unix_ms: null },
+				{ battery_level: 101, user_description: "Invalid", last_read_succeeded: true, observed_at_unix_ms: 3 },
+			],
+		})]);
+		expect(mapped[0].batteryParts.map(part => part.valueStatus)).toEqual([
+			"current", "stale", "unavailable", "unavailable",
+		]);
+	});
+
+	it("marks numeric levels stale while disconnected or unknown", () => {
+		for (const overrides of [{ isDisconnected: true }, { connectionStatusKnown: false }]) {
+			const mapped = buildExternalBatteryDevices([device(overrides)]);
+			expect(mapped[0].batteryParts[0].valueStatus).toBe("stale");
+		}
+	});
+
+	it("does not mutate the source devices", () => {
+		const input = [device()];
+		const before = structuredClone(input);
+		buildExternalBatteryDevices(input);
+		expect(input).toEqual(before);
+	});
+});

--- a/src/utils/appHelpers.ts
+++ b/src/utils/appHelpers.ts
@@ -9,9 +9,35 @@ export type RegisteredDevice = {
 	batteryInfos: BatteryInfo[];
 	isDisconnected: boolean;
 	isCollapsed: boolean;
+	connectionStatusKnown?: boolean;
+	connectionObservedAtUnixMs?: number | null;
 	/** Custom display names per part; keys match battery history user_description (null → "Central"). */
 	batteryPartLabels?: Record<string, string>;
 };
+
+export function isValidBatteryLevel(level: unknown): level is number {
+	return typeof level === "number" && Number.isInteger(level) && level >= 0 && level <= 100;
+}
+
+export function annotateBatteryInfosFromRead(infos: BatteryInfo[], now: number): BatteryInfo[] {
+	return infos.map((info) => isValidBatteryLevel(info.battery_level)
+		? {
+			...info,
+			battery_level: info.battery_level,
+			observed_at_unix_ms: now,
+			last_read_succeeded: true,
+		}
+		: {
+			...info,
+			battery_level: null,
+			observed_at_unix_ms: null,
+			last_read_succeeded: false,
+		});
+}
+
+export function markBatteryInfosReadFailed(infos: BatteryInfo[]): BatteryInfo[] {
+	return infos.map((info) => ({ ...info, last_read_succeeded: false }));
+}
 
 function normalizeBatteryPartLabels(raw: unknown): Record<string, string> | undefined {
 	if (raw === undefined || raw === null) return undefined;
@@ -30,6 +56,10 @@ function normalizeDeviceDisplayName(raw: unknown): string | undefined {
 	if (typeof raw !== "string") return undefined;
 	const t = raw.trim();
 	return t !== "" ? t : undefined;
+}
+
+function normalizeObservedTimestamp(raw: unknown): number | null {
+	return typeof raw === "number" && Number.isInteger(raw) && raw >= 0 ? raw : null;
 }
 
 export function getRegisteredDeviceDisplayName(device: {
@@ -57,22 +87,33 @@ export function upsertBatteryInfo(batteryInfos: BatteryInfo[], nextInfo: Battery
 		return [...batteryInfos, nextInfo];
 	}
 	const next = [...batteryInfos];
-	const merged =
-		nextInfo.battery_level !== null
-			? nextInfo
-			: { ...nextInfo, battery_level: batteryInfos[idx].battery_level };
+	const merged = isValidBatteryLevel(nextInfo.battery_level)
+		? nextInfo
+		: {
+			...nextInfo,
+			battery_level: batteryInfos[idx].battery_level,
+			observed_at_unix_ms: batteryInfos[idx].observed_at_unix_ms ?? null,
+			last_read_succeeded: false,
+		};
 	next[idx] = merged;
 	return next;
 }
 
 export function mergeBatteryInfos(prev: BatteryInfo[], next: BatteryInfo[]): BatteryInfo[] {
 	return next.map((info) => {
-		if (info.battery_level !== null) {
+		if (isValidBatteryLevel(info.battery_level)) {
 			return info;
 		}
 		const key = info.user_description ?? null;
 		const existing = prev.find((p) => (p.user_description ?? null) === key);
-		return existing ? { ...info, battery_level: existing.battery_level } : info;
+		return existing
+			? {
+				...info,
+				battery_level: existing.battery_level,
+				observed_at_unix_ms: existing.observed_at_unix_ms ?? null,
+				last_read_succeeded: false,
+			}
+			: { ...info, battery_level: null, observed_at_unix_ms: null, last_read_succeeded: false };
 	});
 }
 
@@ -81,13 +122,18 @@ export function normalizeLoadedDevices(raw: unknown): RegisteredDevice[] {
 	return devices.map((device): RegisteredDevice => {
 		const d = typeof device === "object" && device !== null ? (device as Record<string, unknown>) : {};
 		const batteryInfos: BatteryInfo[] = Array.isArray(d.batteryInfos)
-			? (d.batteryInfos as Array<Record<string, unknown>>).map((info) => {
-				const rawUserDesc = info.user_description ?? (info as { user_descriptor?: unknown }).user_descriptor;
+			? d.batteryInfos.map((rawInfo): BatteryInfo => {
+				const info = typeof rawInfo === "object" && rawInfo !== null
+					? rawInfo as Record<string, unknown>
+					: {};
+				const rawUserDesc = info.user_description ?? info.user_descriptor;
 				const userDesc = typeof rawUserDesc === "string" || rawUserDesc === null ? rawUserDesc : null;
-				const level = info.battery_level;
+				const level = isValidBatteryLevel(info.battery_level) ? info.battery_level : null;
 				return {
-					battery_level: typeof level === "number" ? level : null,
+					battery_level: level,
 					user_description: userDesc ?? null,
+					observed_at_unix_ms: normalizeObservedTimestamp(info.observed_at_unix_ms),
+					last_read_succeeded: false,
 				};
 			})
 			: [];
@@ -98,14 +144,20 @@ export function normalizeLoadedDevices(raw: unknown): RegisteredDevice[] {
 			return match ? match[1] : value;
 		};
 		const displayName = normalizeDeviceDisplayName(d.displayName);
+		const batteryPartLabels = normalizeBatteryPartLabels(d.batteryPartLabels);
 		const base: RegisteredDevice = {
 			id: extractFromDeviceId(rawId),
 			name: extractFromDeviceId(rawName),
 			batteryInfos,
 			isDisconnected: d.isDisconnected === true,
 			isCollapsed: d.isCollapsed === true,
-			batteryPartLabels: normalizeBatteryPartLabels(d.batteryPartLabels),
+			connectionStatusKnown: false,
+			connectionObservedAtUnixMs: null,
 		};
-		return displayName !== undefined ? { ...base, displayName } : base;
+		return {
+			...base,
+			...(displayName !== undefined ? { displayName } : {}),
+			...(batteryPartLabels !== undefined ? { batteryPartLabels } : {}),
+		};
 	});
 }

--- a/src/utils/ble.ts
+++ b/src/utils/ble.ts
@@ -20,6 +20,8 @@ export type BleDeviceInfo = {
 export type BatteryInfo = {
 	battery_level: number | null;
 	user_description: string | null;
+	observed_at_unix_ms?: number | null;
+	last_read_succeeded?: boolean;
 };
 
 export type BatteryInfoNotificationEvent = {

--- a/src/utils/externalBatteryIntegration.ts
+++ b/src/utils/externalBatteryIntegration.ts
@@ -1,0 +1,105 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { BatteryInfo } from "@/utils/ble";
+import { getRegisteredDeviceDisplayName, isValidBatteryLevel } from "@/utils/appHelpers";
+import type { RegisteredDevice } from "@/utils/appHelpers";
+import { getBatteryPartDisplayName } from "@/utils/batteryLabels";
+
+export type ExternalConnectionStatus = "unknown" | "connected" | "disconnected";
+export type ExternalBatteryValueStatus = "current" | "stale" | "unavailable";
+
+export type ExternalBatteryPart = {
+	id: string;
+	sourceDescription: string | null;
+	displayName: string;
+	levelPercent: number | null;
+	observedAtUnixMs: number | null;
+	valueStatus: ExternalBatteryValueStatus;
+};
+
+export type ExternalBatteryDevice = {
+	id: string;
+	key: string;
+	name: string;
+	displayName: string;
+	connectionStatus: ExternalConnectionStatus;
+	connectionObservedAtUnixMs: number | null;
+	batteryParts: ExternalBatteryPart[];
+};
+
+export type RegisteredDevicesSnapshot = {
+	devices: RegisteredDevice[];
+	sourceRevision: number;
+};
+
+export async function startExternalBatterySourceSession(): Promise<number> {
+	return await invoke("start_external_battery_source_session");
+}
+
+export async function publishExternalBatterySnapshot(
+	sourceGeneration: number,
+	sourceRevision: number,
+	devices: ExternalBatteryDevice[],
+): Promise<void> {
+	await invoke("publish_external_battery_snapshot", {
+		sourceGeneration,
+		sourceRevision,
+		devices,
+	});
+}
+
+export function toStableExternalKey(prefix: string, value: string): string {
+	const bytes = new TextEncoder().encode(value);
+	return `${prefix}${Array.from(bytes, byte => byte.toString(16).padStart(2, "0")).join("")}`;
+}
+
+export function getExternalBatteryPartId(userDescription: string | null): string {
+	return userDescription === null ? "central" : toStableExternalKey("part", userDescription);
+}
+
+function connectionStatusFor(device: RegisteredDevice): ExternalConnectionStatus {
+	if (device.connectionStatusKnown !== true) return "unknown";
+	return device.isDisconnected ? "disconnected" : "connected";
+}
+
+function validTimestamp(value: number | null | undefined): number | null {
+	return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function getValueStatus(
+	level: number | null,
+	connectionStatus: ExternalConnectionStatus,
+	lastReadSucceeded: boolean | undefined,
+): ExternalBatteryValueStatus {
+	if (level === null) return "unavailable";
+	if (connectionStatus !== "connected") return "stale";
+	if (lastReadSucceeded !== true) return "stale";
+	return "current";
+}
+
+export function buildExternalBatteryDevices(devices: RegisteredDevice[]): ExternalBatteryDevice[] {
+	return devices.map((device) => {
+		const connectionStatus = connectionStatusFor(device);
+		return {
+			id: device.id,
+			key: toStableExternalKey("device", device.id),
+			name: device.name,
+			displayName: getRegisteredDeviceDisplayName(device),
+			connectionStatus,
+			connectionObservedAtUnixMs: connectionStatus === "unknown"
+				? null
+				: validTimestamp(device.connectionObservedAtUnixMs),
+			batteryParts: device.batteryInfos.map((info: BatteryInfo) => {
+				const level = isValidBatteryLevel(info.battery_level) ? info.battery_level : null;
+				const valueStatus = getValueStatus(level, connectionStatus, info.last_read_succeeded);
+				return {
+					id: getExternalBatteryPartId(info.user_description),
+					sourceDescription: info.user_description,
+					displayName: getBatteryPartDisplayName(device.batteryPartLabels, info.user_description),
+					levelPercent: level,
+					observedAtUnixMs: validTimestamp(info.observed_at_unix_ms),
+					valueStatus,
+				};
+			}),
+		};
+	});
+}


### PR DESCRIPTION
related: #71

Publish the latest registered keyboard battery state to `battery-state-v1.json`

Details:

- Add atomic JSON publishing under the application data directory
- Include device connection state, battery parts, display labels, timestamps, and value freshness
- Preserve last-known battery levels while marking stale or unavailable values
- Debounce frontend snapshot publishing to avoid unnecessary writes
- Ignore stale frontend snapshots using a source revision
- Add frontend and Rust tests for mapping, persistence, and JSON output

## Scope

This PR intentionally includes only the `battery-state-v1.json` snapshot API.

The following features are not included:

- Formats corresponding to specific apps. They should be implemented in separate repositories, as scripts that convert from `battery-state-v1.json`.
  - RunCat Neo example: https://github.com/kot149/zmk-battery-center-runcat-adapter
- BLE refresh commands for external clients